### PR TITLE
funnannotate -> funannotate in all the logfile names

### DIFF
--- a/bin/funannotate-compare.py
+++ b/bin/funannotate-compare.py
@@ -72,7 +72,7 @@ if not os.path.isdir(ortho_folder):
     os.makedirs(ortho_folder)
 
 #create log file
-log_name = os.path.join(args.out, 'funnannotate-compare.log')
+log_name = os.path.join(args.out, 'funannotate-compare.log')
 if os.path.isfile(log_name):
     os.remove(log_name)
 

--- a/bin/funannotate-fix.py
+++ b/bin/funannotate-fix.py
@@ -25,7 +25,7 @@ parser.add_argument('--isolate', help='Isolate/strain name (e.g. Af293)')
 args=parser.parse_args()
 
 #create log file
-log_name = os.path.join(args.input, 'logfiles', 'funnannotate-fix.log')
+log_name = os.path.join(args.input, 'logfiles', 'funannotate-fix.log')
 if os.path.isfile(log_name):
     os.remove(log_name)
 

--- a/bin/funannotate-functional.py
+++ b/bin/funannotate-functional.py
@@ -57,7 +57,7 @@ def runIPRpython(Input):
     os.remove(OUTPATH+'.out.txt')
 
 #create log file
-log_name = 'funnannotate-functional.log'
+log_name = 'funannotate-functional.log'
 if os.path.isfile(log_name):
     os.remove(log_name)
 


### PR DESCRIPTION
Minor bit, but shouldn't logfiles be named funannotate-XXX not funnannotate-XXX 