### PR TITLE
Calculate dn:ds rations for alignments of > 2 genes 

### DIFF
--- a/lib/library.py
+++ b/lib/library.py
@@ -2734,16 +2734,17 @@ def counttaxa(input):
         ct = line.count(',')+1
     return ct
 
+
 def drawPhyMLtree(fasta, tree):
     FNULL = open(os.devnull, 'w')
     fc = countfasta(fasta)
     #need to convert to phylip format
-    base = fasta.split('.')[0]
+    base = os.path.basename(fasta).split('.')[0]
     tmp1 = base+'.draw2tree.phylip'
     subprocess.call(['trimal', '-in', fasta, '-out', tmp1, '-phylip'])
     #draw tree
     subprocess.call(['phyml', '-i', tmp1], stdout = FNULL, stderr = FNULL)
-    tmp2 = base+'.draw2tree.phylip_phyml_tree.txt'
+    tmp2 = base+'.draw2tree.phylip_phyml_tree'
     #check that num taxa in tree = input
     tc = counttaxa(tmp2)
     if tc != fc: #something failed...
@@ -2754,7 +2755,7 @@ def drawPhyMLtree(fasta, tree):
     #rename and clean
     os.rename(tmp2, tree)
     os.remove(tmp1)
-    os.remove(base+'.draw2tree.phylip_phyml_stats.txt')
+    os.remove(base+'.draw2tree.phylip_phyml_stats')
 
 def simplestTreeEver(fasta, tree):
     with open(tree, 'w') as outfile:


### PR DESCRIPTION
When I used `funannotate compare` with `rundnds` set to one of the options I get no results dn:ds results for any orthogroup with more than sequences.

Digging into this, it turns out funannotate is writing all of the intermediate files for these groups to the root of the `./orthology` directory leaving the orthogroup directories empty.  This seems be the result of parsing the name of the codon alignment file the library function `drawPhyMLtree()`. Here is  a solution that works solves this problem in my hand.

Note, this also changes the names of files to clean up after running phyML. ,phyML does not append ".txt" to these files (at least in v3.3.2 on linux)