### PR TITLE
Fix converting AUGUSTUS_CONFIG_PATH into AUGUSTUS_BASE

### DIFF
--- a/bin/funannotate-predict.py
+++ b/bin/funannotate-predict.py
@@ -178,10 +178,8 @@ else:
             lib.log.error("Bamtools not found and $BAMTOOLS_PATH environmental variable missing, BRAKER is not properly configured. You can use the --BAMTOOLS_PATH argument to specify a path at runtime.")
             sys.exit(1)
 
-if AUGUSTUS.endswith('config'):
-    AUGUSTUS_BASE = AUGUSTUS.replace('config', '')
-elif AUGUSTUS.endswith('config'+os.sep):
-    AUGUSTUS_BASE = AUGUSTUS.replace('config'+os.sep, '')
+if os.path.basename(os.path.normcase(os.path.realpath(AUGUSTUS))) == 'config':
+    AUGUSTUS_BASE = os.path.dirname(os.path.realpath(AUGUSTUS))
 AutoAug = os.path.join(AUGUSTUS_BASE, 'scripts', 'autoAug.pl')
 BAM2HINTS = os.path.join(AUGUSTUS_BASE, 'bin', 'bam2hints')
 GeneMark2GFF = os.path.join(parentdir, 'util', 'genemark_gtf2gff3.pl')


### PR DESCRIPTION
This fixes an issue caused by `AUGUSTUS_CONFIG_PATH` having more than one `'config'` substring, i.e. `'configfiles/augustus/config'` getting converted to `'files/augustus/'`.

I am fairly certain `os.path.realpath` works correctly in all instances. Here's a record of my tests:

```
tjesser@computer:~$ mkdir symbolic_links_test
tjesser@computer:~$ cd symbolic_links_test/
tjesser@computer:~/symbolic_links_test$
tjesser@computer:~/symbolic_links_test$ mkdir start middle finish
tjesser@computer:~/symbolic_links_test$ touch start/start.txt middle/middle.txt finish/finish.txt
tjesser@computer:~/symbolic_links_test$ cd middle/
tjesser@computer:~/symbolic_links_test/middle$
tjesser@computer:~/symbolic_links_test/middle$ ln -s ../start snake
tjesser@computer:~/symbolic_links_test/middle$ ln -s ../finish ladder
tjesser@computer:~/symbolic_links_test/middle$ ls -AXlh
total 0
lrwxrwxrwx 1 tjesser tjesser 9 May  3 17:08 ladder -> ../finish
lrwxrwxrwx 1 tjesser tjesser 8 May  3 17:08 snake -> ../start
-rw-rw-r-- 1 tjesser tjesser 0 May  3 17:07 middle.txt
tjesser@computer:~/symbolic_links_test/middle$ cd ..
tjesser@computer:~/symbolic_links_test$ python2
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os.path
>>>
>>> os.path.realpath('start')
'/home/tjesser/symbolic_links_test/start'
>>> os.path.realpath('start/')
'/home/tjesser/symbolic_links_test/start'
>>>
>>> os.path.realpath('start/start.txt')
'/home/tjesser/symbolic_links_test/start/start.txt'
>>> os.path.realpath('start/notexist.txt')
'/home/tjesser/symbolic_links_test/start/notexist.txt'
>>>
>>> os.path.realpath('middle/snake')
'/home/tjesser/symbolic_links_test/start'
>>> os.path.realpath('middle/snake/notexist.txt')
'/home/tjesser/symbolic_links_test/start/notexist.txt'
>>> os.path.realpath('middle/snake/start.txt')
'/home/tjesser/symbolic_links_test/start/start.txt'
>>>
>>> os.path.realpath('middle/ladder/fakedir/notexist.txt')
'/home/tyler/symbolic_links_test/finish/fakedir/notexist.txt'
>>>
tjesser@computer:~/symbolic_links_test$
```

`os.path.normcase` is only important when we compare the path to a string.

I didn't look at other path arguments. This issue may affect more than just augustus.