### PR TITLE
Added BaseException to catch errors when trying to get version of ins…

### DIFF
--- a/util/check_modules.py
+++ b/util/check_modules.py
@@ -48,6 +48,9 @@ def check_version1(name):
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             return False
+    except BaseException:
+        print "\tERROR: %(name)s found but error running %(name)s"%({'name': name})
+        return False
     return (vers)
     
 def check_version2(name):
@@ -99,6 +102,9 @@ def check_version2(name):
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             return False
+    except BaseException:
+        print "\tERROR: %(name)s found but error running %(name)s"%({'name': name})
+        return False
     return (vers)
     
 def check_version3(name):
@@ -109,6 +115,9 @@ def check_version3(name):
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             return False
+    except BaseException:
+        print "\tERROR: %(name)s found but error running %(name)s"%({'name': name})
+        return False
     return (vers)
 
 def check_version4(name):
@@ -123,6 +132,9 @@ def check_version4(name):
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             return False
+    except BaseException:
+        print "\tERROR: %(name)s found but error running %(name)s"%({'name': name})
+        return False
     return (vers)
 
 def check_version5(name):
@@ -154,6 +166,9 @@ def check_version5(name):
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             return False
+    except BaseException:
+        print "\tERROR: %(name)s found but error running %(name)s"%({'name': name})
+        return False
     return (vers)
 
 def check_version6(name):
@@ -161,6 +176,7 @@ def check_version6(name):
     try:
         if name == 'tRNAscan-SE':
             vers = subprocess.Popen([name, '-h'], stderr=subprocess.PIPE, stdout=subprocess.PIPE).communicate()[1].split('\n')
+
             for i in vers:
                 if i.startswith('tRNAscan-SE'):
                     vers = i
@@ -176,6 +192,9 @@ def check_version6(name):
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             return False
+    except BaseException:
+        print "\tERROR: %(name)s found but error running %(name)s"%({'name': name})
+        return False
     return (vers)
 
     


### PR DESCRIPTION
I ran into a AttributeError: 'list' object has no attribute 'split' when running funannotate check. The reason was a faulty tRNAscan-SE installation. The executable was found, but could not run due to missing perl modules. 
This pull request gives the user a warning which tool does not run properly and continues the check report.
Similar to issue: #205