### PR TITLE
expose ability to use a premade diamond database

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ To install the most updated code in master you can run:
 ```
 python2 -m pip install git+https://github.com/nextgenusfs/funannotate.git
 ```
+
+To install updated code from a locally cloned funannotate git repository:
+```
+conda activate funannotate
+cd funannotate
+python2 -m pip install .
+```

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -268,10 +268,10 @@ else:
     # run Diamond
     #lib.log.info("Running Diamond pre-filter search")
     BlastResult = os.path.join(tmpdir, 'diamond.matches.tab')
-    if args.db != None:
-        abs_dmnd_db = os.path.abspath(args.db)
+    if args.d != None:
+        abs_dmnd_db = os.path.abspath(args.d)
     runDiamond(os.path.abspath(args.genome), os.path.abspath(
-        args.proteins), args.cpus, tmpdir, premade_db=args.db)
+        args.proteins), args.cpus, tmpdir, premade_db=abs_dmnd_db)
     Hits = parseDiamond(BlastResult)
 
 lib.log.info('Found {0:,}'.format(len(Hits)) +

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -76,13 +76,16 @@ if args.filter == 'diamond':
     diamond_version = lib.getDiamondVersion()
 
 
-def runDiamond(input, query, cpus, output):
+def runDiamond(input, query, cpus, output,premade_db=None):
     # create DB of protein sequences
     if int(cpus) > 8:
         cpus = 8
-    cmd = ['diamond', 'makedb', '--threads',
-           str(cpus), '--in', query, '--db', 'diamond']
-    lib.runSubprocess4(cmd, output, lib.log)
+    if premade_db == None:
+        cmd = ['diamond', 'makedb', '--threads',
+               str(cpus), '--in', query, '--db', 'diamond']
+        lib.runSubprocess4(cmd, output, lib.log)
+    else:
+        pass
     # now run search
     cmd = ['diamond', 'blastx', '--threads', str(cpus), '-q', input, '--db', 'diamond',
            '-o', 'diamond.matches.tab', '-e', '1e-10', '-k', '0', '--more-sensitive',

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -87,7 +87,7 @@ def runDiamond(input, query, cpus, output,premade_db=None):
                str(cpus), '--in', query, '--db', 'diamond']
         lib.runSubprocess4(cmd, output, lib.log)
     else:
-        pass
+        os.symlink(premade_db,"diamond")
     # now run search
     cmd = ['diamond', 'blastx', '--threads', str(cpus), '-q', input, '--db', 'diamond',
            '-o', 'diamond.matches.tab', '-e', '1e-10', '-k', '0', '--more-sensitive',

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -268,8 +268,10 @@ else:
     # run Diamond
     #lib.log.info("Running Diamond pre-filter search")
     BlastResult = os.path.join(tmpdir, 'diamond.matches.tab')
+    if args.db != None:
+        abs_dmnd_db = os.path.abspath(args.db)
     runDiamond(os.path.abspath(args.genome), os.path.abspath(
-        args.proteins), args.cpus, tmpdir)
+        args.proteins), args.cpus, tmpdir, premade_db=args.db)
     Hits = parseDiamond(BlastResult)
 
 lib.log.info('Found {0:,}'.format(len(Hits)) +

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -38,6 +38,8 @@ parser.add_argument('--debug', action='store_true',
                     help='Keep intermediate folders if error detected')
 parser.add_argument('-f', '--filter', default='diamond', choices=[
                     'diamond', 'tblastn'], help='Method to use for pre-filter for exonerate')
+parser.add_argument('-d', '--filter_db', default=None,
+                    help='Premade diamond database (of proteins) for prefilter')
 parser.add_argument('--EVM_HOME', 
 					help='Path to Evidence Modeler home directory, $EVM_HOME')
 args = parser.parse_args()

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -87,8 +87,10 @@ def runDiamond(input, query, cpus, output,premade_db=None):
                str(cpus), '--in', query, '--db', 'diamond']
         lib.runSubprocess4(cmd, output, lib.log)
     else:
-        os.symlink(premade_db,"diamond")
+        lib.log.info("Premade Diamond database found:"+premade_db)
+        os.symlink(premade_db,tmpdir+"/diamond")
     # now run search
+    lib.log.info("Now running diamond search...")
     cmd = ['diamond', 'blastx', '--threads', str(cpus), '-q', input, '--db', 'diamond',
            '-o', 'diamond.matches.tab', '-e', '1e-10', '-k', '0', '--more-sensitive',
            '-f', '6', 'sseqid', 'slen', 'sstart', 'send', 'qseqid', 'qlen', 'qstart',
@@ -268,8 +270,10 @@ else:
     # run Diamond
     #lib.log.info("Running Diamond pre-filter search")
     BlastResult = os.path.join(tmpdir, 'diamond.matches.tab')
-    if args.d != None:
-        abs_dmnd_db = os.path.abspath(args.d)
+    if args.filter_db != None:
+        abs_dmnd_db = os.path.abspath(args.filter_db)
+    else:
+        abs_dmnd_db = args.filter_db ##None
     runDiamond(os.path.abspath(args.genome), os.path.abspath(
         args.proteins), args.cpus, tmpdir, premade_db=abs_dmnd_db)
     Hits = parseDiamond(BlastResult)

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -209,7 +209,7 @@ def runExonerate(input):
     exonerate_out = os.path.join(tmpdir, 'exonerate.' + exoname + '.out')
     ryo = "AveragePercentIdentity: %pi\n"
     cmd = ['exonerate', '--model', 'p2g', '--showvulgar', 'no', '--showalignment', 'no',
-           '--showquerygff', 'no', '--showtargetgff', 'yes', '--maxintron', str(args.maxintron), '--percent', '80', '--ryo', ryo, query, scaffold]
+           '--showquerygff', 'no', '--showtargetgff', 'yes', '--maxintron', str(args.maxintron), '--percent', '40', '--ryo', ryo, query, scaffold]
     if lib.checkannotations(query) and lib.checkannotations(scaffold):
         # run exonerate, capture errors
         with open(exonerate_out, 'w') as output3:

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -39,7 +39,7 @@ parser.add_argument('--debug', action='store_true',
 parser.add_argument('-f', '--filter', default='diamond', choices=[
                     'diamond', 'tblastn'], help='Method to use for pre-filter for exonerate')
 parser.add_argument('-d', '--filter_db', default=None,
-                    help='Premade diamond database (of proteins) for prefilter')
+                    help='Premade .dmnd diamond protein database for prefilter')
 parser.add_argument('--EVM_HOME', 
 					help='Path to Evidence Modeler home directory, $EVM_HOME')
 args = parser.parse_args()
@@ -82,13 +82,13 @@ def runDiamond(input, query, cpus, output,premade_db=None):
     # create DB of protein sequences
     if int(cpus) > 8:
         cpus = 8
-    if premade_db == None:
+    if premade_db is None:
         cmd = ['diamond', 'makedb', '--threads',
                str(cpus), '--in', query, '--db', 'diamond']
         lib.runSubprocess4(cmd, output, lib.log)
     else:
-        lib.log.info("Premade Diamond database found:"+premade_db)
-        os.symlink(premade_db,tmpdir+"/diamond")
+        lib.log.info("Using premade Diamond database at:"+premade_db)
+        os.symlink(premade_db,output+"/diamond.dmnd")
     # now run search
     lib.log.info("Now running diamond search...")
     cmd = ['diamond', 'blastx', '--threads', str(cpus), '-q', input, '--db', 'diamond',

--- a/funannotate/aux_scripts/funannotate-runEVM.py
+++ b/funannotate/aux_scripts/funannotate-runEVM.py
@@ -43,7 +43,7 @@ Convert = os.path.join(EVM, 'EvmUtils', 'convert_EVM_outputs_to_GFF3.pl')
 genome_index = arguments.index('--genome')
 genome_args = [arguments[genome_index], arguments[genome_index+1]]
 # base commands
-base_cmd1 = [perl, Partition, '--segmentSize', '100000',
+base_cmd1 = [perl, Partition, '--segmentSize', '1000000000',
              '--overlapSize', '10000', '--partition_listing', 'partitions_list.out']
 base_cmd2 = [perl, Commands, '--output_file_name',
              'evm.out', '--partitions', 'partitions_list.out']

--- a/funannotate/train.py
+++ b/funannotate/train.py
@@ -311,6 +311,7 @@ def runPASAtrain(genome, transcripts, cleaned_transcripts, gff3_alignments, stri
                 line = line.replace('<__DATABASE__>', pasaDBname_path)
                 line = line.replace('<__MYSQLDB__>', pasaDBname_path)
                 config1.write(line)
+            config1.write("validate_alignments_in_db.dbi:--NUM_BP_PERFECT_SPLICE_BOUNDARY=0") ##This helps keep heterozygosity/variation near the splice site.
     if not os.path.isfile(os.path.join(folder, pasaDBname+'.assemblies.fasta')):
         # now run first PASA step, note this will dump any database with same name
         lib.log.info("Running PASA alignment step using {:,} transcripts".format(


### PR DESCRIPTION
Hi there,

I'm trying to wrap funannotate in a Nextflow pipeline so I can more fully parallelize it across our HPC (running on some large eukaryotic genomes, so it helps).  These changes enable the prot2genome.py subscript to be able to use a premade diamond database.  Since the new parameter is exposed as an optional parameter to `runDiamond()`, it should be a transparent change to the rest of funannotate.