### PR TITLE
Minimap2 fixes for very large genomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Latest Github release](https://img.shields.io/github/release/nextgenusfs/funannotate.svg)](https://github.com/nextgenusfs/funannotate/releases/latest)
 [![DOI](https://zenodo.org/badge/48254740.svg)](https://zenodo.org/badge/latestdoi/48254740)
+![Conda](https://img.shields.io/conda/dn/bioconda/funannotate)
 
 funannotate is a pipeline for genome annotation (built specifically for fungi, but will also work with higher eukaryotes). Installation, usage, and more information can be found at [http://funannotate.readthedocs.io](http://funannotate.readthedocs.io)
 

--- a/docs/conda.rst
+++ b/docs/conda.rst
@@ -25,7 +25,7 @@ I'd really like to build a bioconda installation package, but would need some he
     conda create -y -n funannotate python=2.7 numpy pandas scipy matplotlib seaborn \
         natsort scikit-learn psutil biopython requests blast rmblast goatools fisher  \
         bamtools augustus bedtools hmmer exonerate diamond>=0.9 tbl2asn ucsc-pslcdnafilter \
-        samtools raxml trimal mafft>=7 iqtree kallisto bowtie2 infernal mummer minimap2 blat \
+        samtools raxml trimal mafft>=7 iqtree kallisto>=0.46.0 bowtie2 infernal mummer minimap2 blat \
         trinity>=2.6.6 evidencemodeler pasa>=2.3 codingquarry stringtie gmap=2017.11.15 snap \
         ete3 salmon>=0.9 jellyfish>=2.2 htslib trnascan-se hisat2 glimmerhmm \
         trf perl-threaded perl-db-file perl-bioperl perl-dbd-mysql perl-dbd-sqlite \

--- a/funannotate/__version__.py
+++ b/funannotate/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 7, 4)
+VERSION = (1, 7, 3)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/funannotate/__version__.py
+++ b/funannotate/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 7, 3)
+VERSION = (1, 7, 4)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -1402,8 +1402,9 @@ def main(args):
     if os.path.isfile(log_name):
         if not os.path.isdir(os.path.join(outputdir, 'logfiles')):
             os.makedirs(os.path.join(outputdir, 'logfiles'))
-        os.rename(log_name, os.path.join(
+        shutil.copyfile(log_name, os.path.join(
             outputdir, 'logfiles', 'funannotate-annotate.log'))
+        os.remove(log_name)
 
 
 if __name__ == "__main__":

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -78,6 +78,8 @@ if args.filter == 'diamond':
 
 def runDiamond(input, query, cpus, output):
     # create DB of protein sequences
+    if int(cpus) > 8:
+        cpus = 8
     cmd = ['diamond', 'makedb', '--threads',
            str(cpus), '--in', query, '--db', 'diamond']
     lib.runSubprocess4(cmd, output, lib.log)

--- a/funannotate/aux_scripts/iprscan-local.py
+++ b/funannotate/aux_scripts/iprscan-local.py
@@ -47,7 +47,9 @@ def combine_xml(files, output):
             first = data
         else:
             first.extend(data.getchildren())
-	tree._setroot(first)
+    #generate new tree
+    tree = et.ElementTree()
+    tree._setroot(first)
     et.register_namespace("", "http://www.ebi.ac.uk/interpro/resources/schemas/interproscan5")
     tree.write(output, encoding='utf-8', xml_declaration=True)
 
@@ -370,8 +372,8 @@ with open(logfiles[0], 'r') as logcheck:
 if doublecheck:
     # check output file, if present and not empty, then delete temporary directory
     if not args.debug:
-		if os.path.isfile(finalOut):
-			shutil.rmtree(tmpdir)
+        if os.path.isfile(finalOut):
+            shutil.rmtree(tmpdir)
     print('InterProScan5 search has completed successfully!')
     print('Results are here: %s' % finalOut)
 else:

--- a/funannotate/aux_scripts/sam2bam.sh
+++ b/funannotate/aux_scripts/sam2bam.sh
@@ -2,14 +2,16 @@
 
 #simple wrapper for running aligner program and piping output to samtools view/sort
 
-if [ -z "$3" ]; then
-    echo 'Usage: sam2bam.sh "aligner_command" bam_threads bam_output'
+if [ -z "$4" ]; then
+    echo 'Usage: sam2bam.sh "aligner_command" assembly bam_threads bam_output'
     echo '**The double quotes are required around aligner command**'
     exit
 fi
 
 #construct the command
-cmd="$1 | samtools view -@ $2 -bS - | samtools sort -@ $2 -o $3 -"
+cmd="$1 | samtools view -T $2 -@ $3 -bS - | samtools sort --reference $2 -@ $3 -o $4 -"
+
+echo $cmd
 
 #run the command
 eval $cmd

--- a/funannotate/aux_scripts/trinity.py
+++ b/funannotate/aux_scripts/trinity.py
@@ -64,7 +64,7 @@ def runTrinityGG(genome, readTuple, longReads, shortBAM, output, args=False):
         if readTuple[2]:
             hisat2cmd = hisat2cmd + ['-U', readTuple[2]]
         cmd = [os.path.join(parentdir, 'sam2bam.sh'), " ".join(
-            hisat2cmd), str(bamthreads), shortBAM]
+            hisat2cmd), genome, str(bamthreads), shortBAM]
         lib.runSubprocess(cmd, '.', lib.log)
     else:
         lib.log.info('Existig Hisat2 alignments found: {:}'.format(shortBAM))

--- a/funannotate/compare.py
+++ b/funannotate/compare.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import shutil
 import argparse
+import io
 from datetime import datetime
 from goatools import obo_parser
 from Bio import SeqIO
@@ -373,13 +374,13 @@ def main(args):
         pfam_desc.append(PFAM.get(i))
     pfamdf2['descriptions'] = pfam_desc
     # write to file
-    pfamdf2.to_csv(os.path.join(args.out, 'pfam', 'pfam.results.csv'))
+    pfamdf2.to_csv(os.path.join(args.out, 'pfam', 'pfam.results.csv'), encoding='utf-8')
     pfamdf2.reset_index(inplace=True)
     pfamdf2.rename(columns={'index': 'PFAM'}, inplace=True)
     pfamdf2['PFAM'] = '<a target="_blank" href="http://pfam.xfam.org/family/' + \
         pfamdf2['PFAM'].astype(str)+'">'+pfamdf2['PFAM']+'</a>'
     # create html output
-    with open(os.path.join(args.out, 'pfam.html'), 'w') as output:
+    with io.open(os.path.join(args.out, 'pfam.html'), 'w', encoding='utf-8') as output:
         pd.set_option('display.max_colwidth', -1)
         output.write(lib.HEADER)
         output.write(lib.PFAM)

--- a/funannotate/fix.py
+++ b/funannotate/fix.py
@@ -14,7 +14,7 @@ def main(args):
     class MyFormatter(argparse.ArgumentDefaultsHelpFormatter):
         def __init__(self, prog):
             super(MyFormatter, self).__init__(prog, max_help_position=48)
-    parser = argparse.ArgumentParser(prog='updateGBK.py', usage="%(prog)s [options] -f genome.GBK -t genome.tbl",
+    parser = argparse.ArgumentParser(prog='fix', usage="%(prog)s [options] -i genome.GBK -t genome.tbl",
                                      description='''Script will update annotation of a Genbank file with new tbl.''',
                                      epilog="""Written by Jon Palmer (2017) nextgenusfs@gmail.com""",
                                      formatter_class=MyFormatter)

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -5540,12 +5540,12 @@ def SystemInfo():
              (system_os, multiprocessing.cpu_count(), MemoryCheck(), python_vers))
 
 
-def runtRNAscan(input, tmpdir, output):
+def runtRNAscan(input, tmpdir, output,cpus=1):
     tRNAout = os.path.join(tmpdir, 'tRNAscan.out')
     tRNAlenOut = os.path.join(tmpdir, 'tRNAscan.len-filtered.out')
     if os.path.isfile(tRNAout):  # tRNAscan can't overwrite file, so check first
         os.remove(tRNAout)
-    cmd = ['tRNAscan-SE', '-o', tRNAout, input]
+    cmd = ['tRNAscan-SE', '-o', tRNAout, '--thread',cpus,input]
     runSubprocess(cmd, '.', log)
     # enforce NCBI length rules
     with open(tRNAlenOut, 'w') as lenOut:

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -5545,7 +5545,7 @@ def runtRNAscan(input, tmpdir, output,cpus=1):
     tRNAlenOut = os.path.join(tmpdir, 'tRNAscan.len-filtered.out')
     if os.path.isfile(tRNAout):  # tRNAscan can't overwrite file, so check first
         os.remove(tRNAout)
-    cmd = ['tRNAscan-SE', '-o', tRNAout, '--thread',cpus,input]
+    cmd = ['tRNAscan-SE', '-o', tRNAout, '--thread',"%d"%(cpus),input]
     runSubprocess(cmd, '.', log)
     # enforce NCBI length rules
     with open(tRNAlenOut, 'w') as lenOut:

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -7041,6 +7041,7 @@ def dictFlipLookup(input, lookup):
                 result = k+': '+lookup.get(k)
             else:
                 result = k+': No description'
+            result = result.encode('utf-8')
             for i in v:
                 if i in outDict:
                     outDict[i].append(str(result))

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -7280,7 +7280,7 @@ def selectTrainingModels(input, fasta, genemark_gtf, output):
         else:
             if not hit[0] in blastignore:
                 blastignore.append(hit[0])
-    log.debug('{:,} models fail blast identidy threshold'.format(
+    log.debug('{:,} models fail blast identity threshold'.format(
         len(blastignore)))
     SafeRemove('augustus.training.proteins.fa')
     SafeRemove('aug_training.dmnd')

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -4403,7 +4403,7 @@ def minimap2Align(transcripts, genome, cpus, intron, output):
     minimap2_cmd = ['minimap2', '-ax', 'splice', '-t',
                     str(cpus), '--cs', '-u', 'b', '-G', str(intron), genome, transcripts]
     cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-        minimap2_cmd), str(bamthreads), output]
+        minimap2_cmd), genome, str(bamthreads), output]
     runSubprocess(cmd, '.', log)
 
 
@@ -4417,7 +4417,7 @@ def iso_seq_minimap2(transcripts, genome, cpus, intron, output):
     minimap2_cmd = ['minimap2', '-ax', 'splice', '-t',
                     str(cpus), '--cs', '-uf', '-C5', '-G', str(intron), genome, transcripts]
     cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-        minimap2_cmd), str(bamthreads), output]
+        minimap2_cmd), genome, str(bamthreads), output]
     runSubprocess(cmd, '.', log)
 
 
@@ -4431,7 +4431,7 @@ def nanopore_cDNA_minimap2(transcripts, genome, cpus, intron, output):
     minimap2_cmd = ['minimap2', '-ax', 'splice', '-t',
                     str(cpus), '--cs', '-G', str(intron), genome, transcripts]
     cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-        minimap2_cmd), str(bamthreads), output]
+        minimap2_cmd), genome, str(bamthreads), output]
     runSubprocess(cmd, '.', log)
 
 
@@ -4445,7 +4445,7 @@ def nanopore_mRNA_minimap2(transcripts, genome, cpus, intron, output):
     minimap2_cmd = ['minimap2', '-ax', 'splice', '-t',
                     str(cpus), '--cs', '-uf', '-k14', '-G', str(intron), genome, transcripts]
     cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-        minimap2_cmd), str(bamthreads), output]
+        minimap2_cmd), genome, str(bamthreads), output]
     runSubprocess(cmd, '.', log)
 
 

--- a/funannotate/predict.py
+++ b/funannotate/predict.py
@@ -1775,7 +1775,7 @@ If you can run GeneMark outside funannotate you can add with --genemark_gtf opti
     tRNAscan = os.path.join(args.out, 'predict_misc', 'trnascan.gff3')
     if not os.path.isfile(tRNAscan):
         lib.runtRNAscan(MaskGenome, os.path.join(
-            args.out, 'predict_misc'), tRNAscan)
+            args.out, 'predict_misc'), tRNAscan,args.cpus)
 
     # combine tRNAscan with EVM gff, dropping tRNA models if they overlap with EVM models
     cleanTRNA = os.path.join(args.out, 'predict_misc',

--- a/funannotate/remote.py
+++ b/funannotate/remote.py
@@ -297,7 +297,8 @@ def main(args):
     lib.log.info("Remote searches complete")
     # move logfile
     if os.path.isfile(log_name):
-        os.rename(log_name, os.path.join(outputdir, 'logfiles', log_name))
+    	shutil.copyfile(log_name, os.path.join(outputdir, 'logfiles', log_name))
+        os.remove(log_name)
 
 
 if __name__ == "__main__":

--- a/funannotate/test.py
+++ b/funannotate/test.py
@@ -279,7 +279,7 @@ def runCompareTest(args):
     runCMD(['funannotate', 'compare',
             '-i', input1, input2, input3,
             '-o', 'compare', '--cpus', str(args.cpus),
-            '--run_dnds', 'estimate', '--outgroup', 'botrytis_cinerea.dikarya'], tmpdir)
+            '--outgroup', 'botrytis_cinerea.dikarya'], tmpdir)
     print("#########################################################")
     # check results
     try:

--- a/funannotate/train.py
+++ b/funannotate/train.py
@@ -247,7 +247,7 @@ def mapTranscripts(genome, longTuple, assembled, tmpdir, trinityBAM, allBAM, cpu
             minimap_cmd = ['minimap2', '-ax', 'map-ont', '-t',
                            str(cpus), '--secondary=no', assembled, mappedLong]
             cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-                minimap_cmd), str(cpus // 2), crosscheckBAM]
+                minimap_cmd), assembled, str(cpus // 2), crosscheckBAM]
             if not lib.checkannotations(crosscheckBAM):
                 lib.runSubprocess(cmd, '.', lib.log)
             bam2fasta_unmapped(crosscheckBAM, unmappedLong, cpus=cpus)
@@ -1086,7 +1086,7 @@ def main(args):
         minimap_cmd = ['minimap2', '-ax' 'map-ont', '-t',
                        str(args.cpus), '--secondary=no', PASAtranscripts, longReadClean]
         cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-            minimap_cmd), str(args.cpus // 2), minimapBAM]
+            minimap_cmd), PASAtranscripts, str(args.cpus // 2), minimapBAM]
         if not lib.checkannotations(minimapBAM):
             lib.runSubprocess(cmd, '.', lib.log)
         if not lib.checkannotations(KallistoAbundance):

--- a/funannotate/update.py
+++ b/funannotate/update.py
@@ -818,7 +818,7 @@ def mapTranscripts(genome, longTuple, assembled, tmpdir, trinityBAM, allBAM, cpu
             minimap_cmd = ['minimap2', '-ax', 'map-ont', '-t',
                            str(cpus), '--secondary=no', assembled, mappedLong]
             cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-                minimap_cmd), str(cpus // 2), crosscheckBAM]
+                minimap_cmd), assembled, str(cpus // 2), crosscheckBAM]
             if not lib.checkannotations(crosscheckBAM):
                 lib.runSubprocess(cmd, '.', lib.log)
             bam2fasta_unmapped(crosscheckBAM, unmappedLong, cpus=cpus)
@@ -2154,7 +2154,7 @@ def main(args):
         minimap_cmd = ['minimap2', '-ax' 'map-ont', '-t',
                        str(args.cpus), '--secondary=no', PASAtranscripts, longReadClean]
         cmd = [os.path.join(parentdir, 'aux_scripts', 'sam2bam.sh'), " ".join(
-            minimap_cmd), str(args.cpus // 2), minimapBAM]
+            minimap_cmd), assembled, str(args.cpus // 2), minimapBAM]
         if not lib.checkannotations(minimapBAM):
             lib.runSubprocess(cmd, '.', lib.log)
         if not lib.checkannotations(KallistoAbundance):

--- a/scripts/funannotate
+++ b/scripts/funannotate
@@ -132,6 +132,7 @@ Optional:
   -m, --min_coverage       Min depth for normalizing reads. Default: 5
   --pasa_db                Database to use. Default: sqlite [mysql,sqlite]
   --pasa_alignment_overlap PASA --stringent_alignment_overlap. Default: 30.0
+  --aligners               Aligners to use with PASA: Default: minimap2 blat [gmap]
   --max_intronlen          Maximum intron length. Default: 3000
   --species                Species name, use quotes for binomial, e.g. "Aspergillus fumigatus"
   --strain                 Strain name
@@ -245,6 +246,7 @@ Optional:
   --pasa_config            PASA assembly config file, i.e. from previous PASA run
   --pasa_db                Database to use. Default: sqlite [mysql,sqlite]
   --pasa_alignment_overlap PASA --stringent_alignment_overlap. Default: 30.0
+  --aligners               Aligners to use with PASA: Default: minimap2 blat [gmap]
   --max_intronlen          Maximum intron length. Default: 3000
   --min_protlen            Minimum protein length. Default: 50
   --alt_transcripts        Expression threshold (percent) to keep alt transcripts. Default: 0.1 [0-1]


### PR DESCRIPTION
Resolves #432 

Minimap2 does not output certain SAM fields with very large genome files, because samtools supports passing in a reference FASTA for downstream tasks such as sort. This changes the appropriate scripts. Tested for training step, the rest will be tested over the next few days as my annotation progresses.

Cheers.