### PR TITLE
updated date parsing for interpro scan

### DIFF
--- a/funannotate/setupDB.py
+++ b/funannotate/setupDB.py
@@ -428,8 +428,12 @@ def interproDB(info, force=False, args={}):
                         num_records = int(x.attrib['entry_count'])
                         version = x.attrib['version']
                         iprdate = x.attrib['file_date']
-        iprdate = datetime.datetime.strptime(
-            iprdate, "%d-%b-%y").strftime("%Y-%m-%d")
+        try:
+            iprdate = datetime.datetime.strptime(
+                iprdate, "%d-%b-%y").strftime("%Y-%m-%d")
+        except ValueError:
+            iprdate = datetime.datetime.strptime(
+                iprdate, "%d-%b-%Y").strftime("%Y-%m-%d")
         info['interpro'] = ('xml', iprXML, version, iprdate, num_records, md5)
     type, name, version, date, records, checksum = info.get('interpro')
     lib.log.info('InterProScan XML: version={:} date={:} records={:,}'.format(


### PR DESCRIPTION
Basically, the strategy is to try the old format, catch the expected error on new format, then try the new format. It strikes me as vaguely inelegant but it works.

My testing here is limited to just verifying that the setup command completes successfully on the new version of the "interpro.xml" file. I don't have the old one to test on nor is it clear how I would do so.
Fixes #437 