### PR TITLE
update parameter from antismash5 to antismash6

### DIFF
--- a/funannotate/remote.py
+++ b/funannotate/remote.py
@@ -233,7 +233,7 @@ def main(args):
             base_address = "https://fungismash.secondarymetabolites.org"
             job_parameters = {'email': args.email, 'ncbi': '', 'smcogs': 'on',
                               'knownclusterblast': 'on', 'activesitefinder': 'on',
-                              'subclusterblast': 'on', 'jobtype': 'antismash5',
+                              'subclusterblast': 'on', 'jobtype': 'antismash6',
                               'hmmdetection_strictness': 'relaxed'}
         elif args.antismash == 'plants':
             base_address = "https://plantismash.secondarymetabolites.org"


### PR DESCRIPTION
antismash doesn't allow job_type antismash5 anymore

```{'error': 'Bad request', 'message': 'Invalid jobtype antismash5'}```

I've just changed the parameter to antismash6 and its running fine now.
