### PR TITLE
Combine runSubprocessN into a single function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 dockerbuild/
 sample_data/
 .DS_Store
+funannotate.egg-info
+.idea

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -34,7 +34,7 @@ def MEROPSBlast(input, cpus, evalue, tmpdir, output, diamond=True):
         cmd = ['blastp', '-db', blastdb, '-outfmt', '5', '-out', blast_tmp, '-num_threads', str(cpus),
                '-max_target_seqs', '1', '-evalue', str(evalue), '-query', input]
     if not os.path.isfile(blast_tmp):
-        lib.runSubprocess4(cmd, '.', lib.log)
+        lib.runSubprocess(cmd, '.', lib.log, only_failed=True)
     # parse results
     with open(output, 'w') as out:
         with open(blast_tmp, 'r') as results:
@@ -64,7 +64,7 @@ def SwissProtBlast(input, cpus, evalue, tmpdir, GeneDict, diamond=True):
                '-num_threads', str(cpus), '-max_target_seqs', '1',
                '-evalue', str(evalue), '-query', input]
     if not lib.checkannotations(blast_tmp):
-        lib.runSubprocess4(cmd, '.', lib.log)
+        lib.runSubprocess(cmd, '.', lib.log, only_failed=True)
     # parse results
     counter = 0
     total = 0
@@ -1443,7 +1443,7 @@ def main(args):
                '--db', mibig_db, '--max-hsps', '1',
                '--evalue', '0.001', '--max-target-seqs', '1',
                '--outfmt', '6']
-        lib.runSubprocess4(cmd, '.', lib.log)
+        lib.runSubprocess(cmd, '.', lib.log, only_failed=True)
         # now parse blast results to get {qseqid: hit}
         MIBiGBlast = {}
         with open(mibig_blast, 'r') as input:

--- a/funannotate/aux_scripts/augustus_parallel.py
+++ b/funannotate/aux_scripts/augustus_parallel.py
@@ -97,7 +97,7 @@ def runAugustus(Input):
         core_cmd.insert(2, '--predictionStart='+str(start))
         core_cmd.insert(3, '--predictionEnd='+str(end))
     # try using library module
-    lib.runSubprocess2(core_cmd, '.', lib.log, aug_out)
+    lib.runSubprocess(core_cmd, '.', lib.log, capture_output=aug_out)
 
 
 log_name = args.logfile

--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -109,13 +109,13 @@ def runDiamond(input, query, cpus, output, premade_db=None):
     if premade_db is None:
         db_cmd = ['diamond', 'makedb', '--threads',
                   str(cpus), '--in', query, '--db', 'diamond']
-        lib.runSubprocess4(db_cmd, output, lib.log)
+        lib.runSubprocess(db_cmd, output, lib.log, only_failed=True)
     else:
         lib.log.debug('Using premade Diamond database: {}'.format(premade_db))
         os.symlink(os.path.abspath(premade_db),
                    os.path.join(output, 'diamond.dmnd'))
     # now run search
-    lib.runSubprocess4(cmd, output, lib.log)
+    lib.runSubprocess(cmd, output, lib.log, only_failed=True)
 
 
 def runtblastn(input, query, cpus, output, maxhits):

--- a/funannotate/aux_scripts/phobius-multiproc.py
+++ b/funannotate/aux_scripts/phobius-multiproc.py
@@ -51,7 +51,7 @@ def runPhobiusLocal(Input):
     base = base.split('.fa')[0]
     OUTPATH = os.path.join(TMPDIR, base+'.phobius')
     cmd = ['phobius.pl', '-short', Input]
-    lib.runSubprocess2(cmd, TMPDIR, lib.log, OUTPATH)
+    lib.runSubprocess(cmd, TMPDIR, lib.log, capture_output=OUTPATH)
 
 
 global parentdir

--- a/funannotate/aux_scripts/trinity.py
+++ b/funannotate/aux_scripts/trinity.py
@@ -46,7 +46,7 @@ def runTrinityGG(genome, readTuple, longReads, shortBAM, output, args=False):
         lib.log.info("Building Hisat2 genome index")
         cmd = ['hisat2-build', '-p',
                str(args.cpus), genome, os.path.join(tmpdir, 'hisat2.genome')]
-        lib.runSubprocess4(cmd, '.', lib.log)
+        lib.runSubprocess(cmd, '.', lib.log, only_failed=True)
         # align reads using hisat2
         lib.log.info("Aligning reads to genome using Hisat2")
         # use bash wrapper for samtools piping for SAM -> BAM -> sortedBAM
@@ -96,7 +96,7 @@ def runTrinityGG(genome, readTuple, longReads, shortBAM, output, args=False):
     cmd = cmd + jaccard_clip
     if longReads and lib.checkannotations(longReads):
         cmd = cmd + ['--long_reads', os.path.realpath(longReads)]
-    lib.runSubprocess2(cmd, '.', lib.log, TrinityLog)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=TrinityLog)
     commands = os.path.join(tmpdir, 'trinity_gg', 'trinity_GG.cmds')
 
     # this will create all the Trinity commands, will now run these in parallel using multiprocessing
@@ -122,7 +122,7 @@ def runTrinityGG(genome, readTuple, longReads, shortBAM, output, args=False):
     # now grab them all using Trinity script
     cmd = ['perl', os.path.abspath(os.path.join(
         TRINITY, 'util', 'support_scripts', 'GG_partitioned_trinity_aggregator.pl')), 'Trinity_GG']
-    lib.runSubprocess5(cmd, '.', lib.log, outputfiles, output)
+    lib.runSubprocess(cmd, '.', lib.log, in_file=outputfiles, capture_output=output)
     lib.log.info('{:,} transcripts derived from Trinity'.format(
         lib.countfasta(output)))
 

--- a/funannotate/mask.py
+++ b/funannotate/mask.py
@@ -16,7 +16,7 @@ import funannotate.library as lib
 def runTanTan(input, output):
     # this is the simplest masking solution, although certainly not ideal
     cmd = ['tantan', '-c', input]
-    lib.runSubprocess2(cmd, '.', lib.log, output)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=output)
 
 
 def RepeatModelMask(input, cpus, tmpdir, output, repeatlib, debug):

--- a/funannotate/predict.py
+++ b/funannotate/predict.py
@@ -941,9 +941,9 @@ def main(args):
                                '-ignoreNs', '-bestOverlap', blat_out, blat_filt]
                         lib.runSubprocess(cmd, '.', lib.log)
                         cmd = ['sort', '-n', '-k', '16,16', blat_filt]
-                        lib.runSubprocess2(cmd, '.', lib.log, blat_sort1)
+                        lib.runSubprocess(cmd, '.', lib.log, capture_output=blat_sort1)
                         cmd = ['sort', '-s', '-k', '14,14', blat_sort1]
-                        lib.runSubprocess2(cmd, '.', lib.log, blat_sort2)
+                        lib.runSubprocess(cmd, '.', lib.log, capture_output=blat_sort2)
                         # run blat2hints
                         if lib.which('blat2hints.pl'):
                             blat2hints = 'blat2hints.pl'
@@ -993,12 +993,12 @@ def main(args):
                 bamjoinedhints = os.path.join(
                     args.out, 'predict_misc', 'bam_hints.joined.tmp')
                 cmd = [JOINHINTS]
-                lib.runSubprocess5(cmd, '.', lib.log,
-                                   bamhintssorted, bamjoinedhints)
+                lib.runSubprocess(cmd, '.', lib.log,
+                                  in_file=bamhintssorted, capture_output=bamjoinedhints)
                 # filter intron hints
                 cmd = [os.path.join(
                     parentdir, 'aux_scripts', 'filterIntronsFindStrand.pl'), MaskGenome, bamjoinedhints, '--score']
-                lib.runSubprocess2(cmd, '.', lib.log, hintsBAM)
+                lib.runSubprocess(cmd, '.', lib.log, capture_output=hintsBAM)
             else:
                 lib.log.info(
                     "Existing RNA-seq BAM hints found: {:}".format(hintsBAM))
@@ -1073,7 +1073,7 @@ def main(args):
             args.out, 'predict_misc', 'hints.all.sort.tmp')
         lib.sortHints(allhintstmp, allhintstmp_sort)
         cmd = [JOINHINTS]
-        lib.runSubprocess5(cmd, '.', lib.log, allhintstmp_sort, hints_all)
+        lib.runSubprocess(cmd, '.', lib.log, in_file=allhintstmp_sort, capture_output=hints_all)
 
         Augustus, GeneMark = (None,)*2
 
@@ -1084,11 +1084,11 @@ def main(args):
             GeneMarkGFF3 = os.path.join(
                 args.out, 'predict_misc', 'genemark.gff')
             cmd = [GeneMark2GFF, args.genemark_gtf]
-            lib.runSubprocess2(cmd, '.', lib.log, GeneMarkGFF3)
+            lib.runSubprocess(cmd, '.', lib.log, capture_output=GeneMarkGFF3)
             GeneMarkTemp = os.path.join(
                 args.out, 'predict_misc', 'genemark.temp.gff')
             cmd = ['perl', Converter, GeneMarkGFF3]
-            lib.runSubprocess2(cmd, '.', lib.log, GeneMarkTemp)
+            lib.runSubprocess(cmd, '.', lib.log, capture_output=GeneMarkTemp)
             GeneMark = os.path.join(
                 args.out, 'predict_misc', 'genemark.evm.gff3')
             with open(GeneMark, 'w') as output:
@@ -1142,7 +1142,7 @@ If you can run GeneMark outside funannotate you can add with --genemark_gtf opti
                 GeneMarkTemp2 = os.path.join(
                     args.out, 'predict_misc', 'genemark.temp2.gff')
                 cmd = ['perl', Converter, GeneMarkTemp]
-                lib.runSubprocess2(cmd, '.', lib.log, GeneMarkTemp2)
+                lib.runSubprocess(cmd, '.', lib.log, capture_output=GeneMarkTemp2)
                 with open(GeneMark, 'w') as output:
                     with open(GeneMarkTemp2, 'r') as input:
                         lines = input.read().replace("Augustus", "GeneMark")
@@ -1162,7 +1162,7 @@ If you can run GeneMark outside funannotate you can add with --genemark_gtf opti
                     GeneMarkTemp = os.path.join(
                         args.out, 'predict_misc', 'genemark.temp.gff')
                     cmd = ['perl', Converter, GeneMarkGFF3]
-                    lib.runSubprocess2(cmd, '.', lib.log, GeneMarkTemp)
+                    lib.runSubprocess(cmd, '.', lib.log, capture_output=GeneMarkTemp)
                     GeneMark = os.path.join(
                         args.out, 'predict_misc', 'genemark.evm.gff3')
                     with open(GeneMark, 'w') as output:
@@ -1215,7 +1215,7 @@ If you can run GeneMark outside funannotate you can add with --genemark_gtf opti
                     GeneMarkTemp = os.path.join(
                         args.out, 'predict_misc', 'genemark.temp.gff')
                     cmd = ['perl', Converter, GeneMarkGFF3]
-                    lib.runSubprocess2(cmd, '.', lib.log, GeneMarkTemp)
+                    lib.runSubprocess(cmd, '.', lib.log, capture_output=GeneMarkTemp)
                     GeneMark = os.path.join(
                         args.out, 'predict_misc', 'genemark.evm.gff3')
                     with open(GeneMark, 'w') as output:
@@ -1372,7 +1372,7 @@ If you can run GeneMark outside funannotate you can add with --genemark_gtf opti
                 FILTERGENE = os.path.join(parentdir, 'aux_scripts', 'filterGenemark.pl')
             cmd = [FILTERGENE, os.path.abspath(trainingModels),
                     os.path.abspath(hints_all)]
-            lib.runSubprocess4(cmd, os.path.join(args.out, 'predict_misc'), lib.log)
+            lib.runSubprocess(cmd, os.path.join(args.out, 'predict_misc'), lib.log, only_failed=True)
             totalTrain = lib.selectTrainingModels(PASA_GFF,
                                                   MaskGenome,
                                                   os.path.join(args.out, 'predict_misc', 'pasa.training.tmp.f.good.gtf'),
@@ -1440,7 +1440,7 @@ If you can run GeneMark outside funannotate you can add with --genemark_gtf opti
                 lib.log.info("Existing Augustus annotations found: {:}".format(aug_out))
         Augustus = os.path.join(args.out, 'predict_misc', 'augustus.evm.gff3')
         cmd = ['perl', Converter, aug_out]
-        lib.runSubprocess2(cmd, '.', lib.log, Augustus)
+        lib.runSubprocess(cmd, '.', lib.log, capture_output=Augustus)
 
         # make sure Augustus finished successfully
         if not lib.checkannotations(Augustus):

--- a/funannotate/train.py
+++ b/funannotate/train.py
@@ -84,14 +84,14 @@ def runNormalization(readTuple, memory, min_coverage=5, coverage=50, cpus=1, str
                '--seqType', 'fq', '--output', os.path.join(tmpdir, 'normalize'), '--CPU', str(cpus)]
     if readTuple[2]:  # single reads present, so run normalization just on those reads
         cmd = cmd + ['--single', readTuple[2]]
-        lib.runSubprocess2(cmd, '.', lib.log, SENormalLog)
+        lib.runSubprocess(cmd, '.', lib.log, capture_output=SENormalLog)
         single_norm = os.path.join(tmpdir, 'normalize', 'single.norm.fq')
     if readTuple[0] and readTuple[1]:
         cmd = cmd + ['--pairs_together', '--left',
                      readTuple[0], '--right', readTuple[1]]
         left_norm = os.path.join(tmpdir, 'normalize', 'left.norm.fq')
         right_norm = os.path.join(tmpdir, 'normalize', 'right.norm.fq')
-        lib.runSubprocess2(cmd, '.', lib.log, PENormalLog)
+        lib.runSubprocess(cmd, '.', lib.log, capture_output=PENormalLog)
     return left_norm, right_norm, single_norm
 
 
@@ -194,7 +194,7 @@ def runSeqClean(input, folder, cpus=1):
 def bam2fasta(input, output, cpus=1):
     tmpout = output+'.tmp'
     cmd = ['samtools', 'fasta', '-@', str(cpus), '-F', '0x4', input]
-    lib.runSubprocess2(cmd, '.', lib.log, tmpout)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=tmpout)
     # make sure no empty sequences
     with open(output, 'w') as outfile:
         with open(tmpout, 'r') as infile:
@@ -207,7 +207,7 @@ def bam2fasta(input, output, cpus=1):
 def bam2fasta_unmapped(input, output, cpus=1):
     tmpout = output+'.tmp'
     cmd = ['samtools', 'fasta', '-@', str(cpus), '-f', '0x4', input]
-    lib.runSubprocess2(cmd, '.', lib.log, tmpout)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=tmpout)
     # make sure no empty sequences
     with open(output, 'w') as outfile:
         with open(tmpout, 'r') as infile:
@@ -433,7 +433,7 @@ def runPASAtrain(genome, transcripts, cleaned_transcripts, gff3_alignments,
             cmd = cmd + ['--transcribed_is_aligned_orient']
         if lib.checkannotations(stringtie_gtf):
             cmd = cmd + ['--trans_gtf', os.path.abspath(stringtie_gtf)]
-        lib.runSubprocess6(cmd, folder, lib.log, pasaLOG)
+        lib.runSubprocess(cmd, folder, lib.log, capture_output=pasaLOG, capture_error="STDOUT")
     else:
         lib.log.info('Existing PASA assemblies found: {:}'.format(
             os.path.join(folder, pasaDBname+'.assemblies.fasta')))
@@ -457,7 +457,7 @@ def runPASAtrain(genome, transcripts, cleaned_transcripts, gff3_alignments,
     cmd = [os.path.join(PASA, 'scripts', 'pasa_asmbls_to_training_set.dbi'),
            '--pasa_transcripts_fasta', pasaDBname+'.assemblies.fasta',
            '--pasa_transcripts_gff3', pasaDBname+'.pasa_assemblies.gff3']
-    lib.runSubprocess6(cmd, folder, lib.log, transdecoder_log)
+    lib.runSubprocess(cmd, folder, lib.log, capture_output=transdecoder_log, capture_error="STDOUT")
     # grab final result
     shutil.copyfile(pasa_training_gff, output)
     lib.log.info(
@@ -498,7 +498,7 @@ def runKallisto(input, fasta, readTuple, stranded, cpus, folder, output):
     cmd = [os.path.join(PASA, 'misc_utilities', 'gff3_file_to_proteins.pl'),
            input, fasta, 'cDNA']
     lib.log.info("Building Kallisto index")
-    lib.runSubprocess2(cmd, '.', lib.log, PASAtranscripts)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=PASAtranscripts)
     # generate kallisto index
     cmd = ['kallisto', 'index', '-i', os.path.join(folder, 'bestModel'),
            PASAtranscripts]
@@ -1129,7 +1129,7 @@ def main(args):
                 else:
                     cmd = cmd + ['--fr']
             cmd = cmd + [shortBAM]
-            lib.runSubprocess8(cmd, '.', lib.log, stringtieGTF)
+            lib.runSubprocess(cmd, '.', lib.log, capture_output=stringtieGTF, only_failed=True)
 
 
     # run SeqClean to clip polyA tails and remove low quality seqs.
@@ -1222,7 +1222,7 @@ def main(args):
         cmd = [os.path.join(
             PASA, 'misc_utilities', 'gff3_file_to_proteins.pl'), PASA_tmp, genome, 'cDNA']
         if not lib.checkannotations(PASAtranscripts):
-            lib.runSubprocess2(cmd, '.', lib.log, PASAtranscripts)
+            lib.runSubprocess(cmd, '.', lib.log, capture_output=PASAtranscripts)
         PASAdict = pasa_transcript2gene(PASAtranscripts)
         minimapBAM = os.path.join(tmpdir, 'long-reads_transcripts.bam')
         minimap2_cmd = ['minimap2', '-ax' 'map-ont', '-t',

--- a/funannotate/update.py
+++ b/funannotate/update.py
@@ -349,7 +349,7 @@ def Funzip(input, output, cpus):
     else:
         cmd = ['gzip', '--decompress', '-c', input]
     try:
-        lib.runSubprocess2(cmd, '.', lib.log, output)
+        lib.runSubprocess(cmd, '.', lib.log, capture_output=output)
     except NameError:
         with open(output, 'w') as outfile:
             subprocess.call(cmd, stdout=outfile)
@@ -364,7 +364,7 @@ def Fzip(input, output, cpus):
     else:
         cmd = ['gzip', '-c', input]
     try:
-        lib.runSubprocess2(cmd, '.', lib.log, output)
+        lib.runSubprocess(cmd, '.', lib.log, capture_output=output)
     except NameError:
         with open(output, 'w') as outfile:
             subprocess.call(cmd, stdout=outfile)
@@ -439,14 +439,14 @@ def runNormalization(readTuple, memory, min_coverage=5, coverage=50, cpus=1, str
                '--seqType', 'fq', '--output', os.path.join(tmpdir, 'normalize'), '--CPU', str(cpus)]
     if readTuple[2]:  # single reads present, so run normalization just on those reads
         cmd = cmd + ['--single', readTuple[2]]
-        lib.runSubprocess2(cmd, '.', lib.log, SENormalLog)
+        lib.runSubprocess(cmd, '.', lib.log, capture_output=SENormalLog)
         single_norm = os.path.join(tmpdir, 'normalize', 'single.norm.fq')
     if readTuple[0] and readTuple[1]:
         cmd = cmd + ['--pairs_together', '--left',
                      readTuple[0], '--right', readTuple[1]]
         left_norm = os.path.join(tmpdir, 'normalize', 'left.norm.fq')
         right_norm = os.path.join(tmpdir, 'normalize', 'right.norm.fq')
-        lib.runSubprocess2(cmd, '.', lib.log, PENormalLog)
+        lib.runSubprocess(cmd, '.', lib.log, capture_output=PENormalLog)
     return left_norm, right_norm, single_norm
 
 
@@ -458,7 +458,7 @@ def concatenateReads(input, output):
     '''
     cmd = ['cat']
     cmd = cmd + input
-    lib.runSubprocess2(cmd, '.', lib.log, output)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=output)
 
 
 def getPASAinformation(configFile, DBname, folder, genome):
@@ -483,7 +483,7 @@ def getPASAinformation(configFile, DBname, folder, genome):
     pasaExistingGFF = os.path.join(folder, 'existing_pasa.gff3')
     cmd = [os.path.join(PASA, 'scripts', 'pasa_asmbl_genes_to_GFF3.dbi'),
            '-M', DBname+':'+mysqlDB, '-p', mysqlUser+':'+mysqlPass]
-    lib.runSubprocess2(cmd, folder, lib.log, pasaExistingGFF)
+    lib.runSubprocess(cmd, folder, lib.log, capture_output=pasaExistingGFF)
     if not lib.checkannotations(pasaExistingGFF):
         return False
     # now get number of genes and list of contigs
@@ -575,7 +575,7 @@ def runPASA(genome, transcripts, cleanTranscripts, gff3_alignments,
                     cmd = cmd + ['--transcribed_is_aligned_orient']
                 if lib.checkannotations(stringtie_gtf):
                     cmd = cmd + ['--trans_gtf', stringtie_gtf]
-                lib.runSubprocess6(cmd, folder, lib.log, pasaLOG)
+                lib.runSubprocess(cmd, folder, lib.log, capture_output=pasaLOG, capture_error="STDOUT")
         else:
             lib.log.info('PASA database is SQLite: {:}'.format(DataBaseName))
         # finally need to index the genome using cdbfasta so lookups can be done
@@ -622,7 +622,7 @@ def runPASA(genome, transcripts, cleanTranscripts, gff3_alignments,
             cmd = cmd + ['--transcribed_is_aligned_orient']
         if lib.checkannotations(stringtie_gtf):
             cmd = cmd + ['--trans_gtf', stringtie_gtf]
-        lib.runSubprocess6(cmd, folder, lib.log, pasaLOG)
+        lib.runSubprocess(cmd, folder, lib.log, capture_output=pasaLOG, capture_error="STDOUT")
 
     # generate comparison template file
     with open(annotConfig, 'w') as config2:
@@ -642,7 +642,7 @@ def runPASA(genome, transcripts, cleanTranscripts, gff3_alignments,
         cmd = cmd + ['--annots', os.path.abspath(previousGFF)]
     else:
         cmd = cmd + ['--annots_gff3', os.path.abspath(previousGFF)]
-    lib.runSubprocess6(cmd, folder, lib.log, pasaLOG1)
+    lib.runSubprocess(cmd, folder, lib.log, capture_output=pasaLOG1, capture_error="STDOUT")
     round1GFF = None
     for file in os.listdir(folder):
         if not file.endswith('.gff3'):
@@ -662,7 +662,7 @@ def runPASA(genome, transcripts, cleanTranscripts, gff3_alignments,
         cmd = cmd + ['--annots', os.path.abspath(round1GFF)]
     else:
         cmd = cmd + ['--annots_gff3', os.path.abspath(round1GFF)]
-    lib.runSubprocess6(cmd, folder, lib.log, pasaLOG2)
+    lib.runSubprocess(cmd, folder, lib.log, capture_output=pasaLOG2, capture_error="STDOUT")
     round2GFF = None
     for file in os.listdir(folder):
         if not file.endswith('.gff3'):
@@ -796,7 +796,7 @@ def runSeqClean(input, folder, cpus=1):
 def bam2fasta(input, output, cpus=1):
     tmpout = output+'.tmp'
     cmd = ['samtools', 'fasta', '-@', str(cpus), '-F', '0x4', input]
-    lib.runSubprocess2(cmd, '.', lib.log, tmpout)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=tmpout)
     # make sure no empty sequences
     with open(output, 'w') as outfile:
         with open(tmpout, 'r') as infile:
@@ -809,7 +809,7 @@ def bam2fasta(input, output, cpus=1):
 def bam2fasta_unmapped(input, output, cpus=1):
     tmpout = output+'.tmp'
     cmd = ['samtools', 'fasta', '-@', str(cpus), '-f', '0x4', input]
-    lib.runSubprocess2(cmd, '.', lib.log, tmpout)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=tmpout)
     # make sure no empty sequences
     with open(output, 'w') as outfile:
         with open(tmpout, 'r') as infile:
@@ -990,7 +990,7 @@ def runKallisto(input, fasta, readTuple, stranded, cpus, output):
     cmd = [os.path.join(PASA, 'misc_utilities',
                         'gff3_file_to_proteins.pl'), input, fasta, 'cDNA']
     lib.log.info("Building Kallisto index")
-    lib.runSubprocess2(cmd, '.', lib.log, PASAtranscripts)
+    lib.runSubprocess(cmd, '.', lib.log, capture_output=PASAtranscripts)
     # generate kallisto index
     cmd = ['kallisto', 'index', '-i',
            os.path.join(folder, 'bestModel'), PASAtranscripts]
@@ -2204,7 +2204,7 @@ def main(args):
                     else:
                         cmd = cmd + ['--fr']
                 cmd = cmd + [shortBAM]
-                lib.runSubprocess8(cmd, '.', lib.log, stringtieGTF)
+                lib.runSubprocess(cmd, '.', lib.log, capture_output=stringtieGTF, only_failed=True)
 
     # run SeqClean to clip polyA tails and remove low quality seqs.
     cleanTranscripts = trinity_transcripts+'.clean'
@@ -2285,7 +2285,7 @@ def main(args):
         cmd = [os.path.join(
             PASA, 'misc_utilities', 'gff3_file_to_proteins.pl'), PASA_gff, fastaout, 'cDNA']
         if not lib.checkannotations(PASAtranscripts):
-            lib.runSubprocess2(cmd, '.', lib.log, PASAtranscripts)
+            lib.runSubprocess(cmd, '.', lib.log, capture_output=PASAtranscripts)
         PASAdict = pasa_transcript2gene(PASAtranscripts)
         minimapBAM = os.path.join(tmpdir, 'long-reads_transcripts.bam')
         minimap2_cmd = ['minimap2', '-ax' 'map-ont', '-t',


### PR DESCRIPTION
First of all, thanks for putting together a great tool. I'm using on about 4 different projects now.
 
When I was tracking down some errors I was having with a run, I found that there are 8 different versions of runSubprocess, which made it a bit difficult to determine what was going on. I've combined them into a single function (and context manager). I ran `funannotate test` on the modified version and everything passed successfully. 

The original functions can be replicated as follows:
```
runSubprocess(cmd, '.', lib.log) -> runSubprocess(cmd, '.', lib.log)
runSubprocess2(cmd, '.', lib.log, output_file) -> runSubprocess(cmd, '.', lib.log, capture_output=output_file)
runSubprocess3(cmd, '.', lib.log) -> runSubprocess(cmd, '.', lib.log, capture_output=False)
runSubprocess4(cmd, '.', lib.log) -> runSubprocess(cmd, '.', lib.log, only_failed=True)
runSubprocess5(cmd, '.', lib.log, input_file, output_file) -> runSubprocess(cmd, '.', lib.log, input=input_file, capture_output=output_file)
runSubprocess6(cmd, '.', lib.log, logfile2) -> runSubprocess(cmd, '.', lib.log, capture_output=logfile2, capture_error="STDOUT")
runSubprocess7 - didn't replicate, found no uses
runSubprocess8(cmd, '.', lib.log, output_file) -> runSubprocess(cmd, '.', lib.log, capture_output=output_file, only_failed=True)
```
