### PR TITLE
Fix funannotate_runEVM.py running with .gff3 input ending with empty line.

### DIFF
--- a/funannotate/aux_scripts/funannotate-runEVM.py
+++ b/funannotate/aux_scripts/funannotate-runEVM.py
@@ -21,11 +21,12 @@ def gene_blocks_to_interlap(input):
     with open(input, 'r') as infile:
         for gene_model in lib.readBlocks(infile, '\n'):
             # will be list of lines, so need to find gene line
-            if gene_model[0] == '\n':
-                cols = gene_model[1].split('\t')
-            else:
-                cols = gene_model[0].split('\t')
-            inter[cols[0]].add((int(cols[3]), int(cols[4]), gene_model))
+            if len(gene_model) > 1: # last line is has only a single element
+                if gene_model[0] == '\n':
+                    cols = gene_model[1].split('\t')
+                else:
+                    cols = gene_model[0].split('\t')
+                inter[cols[0]].add((int(cols[3]), int(cols[4]), gene_model))
     return inter
 
 


### PR DESCRIPTION
Potential fix for this issue: https://github.com/nextgenusfs/funannotate/issues/664#issuecomment-1092844856

Checks if the line is empty, and if so, skips.