### PR TITLE
Fix parameter for python 3.6 compatibility

### DIFF
--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -723,7 +723,7 @@ def runSubprocess(cmd, directory, logfile, capture_output=True, capture_error=Tr
 
     logfile.debug(' '.join(cmd))
     with process_handle(capture_output) as p_out, process_handle(capture_error) as p_error, process_handle(in_file, mode="r") as p_in:
-        process = subprocess.run(cmd, cwd=directory, stdin=p_in, stdout=p_out, stderr=p_error, text=True)
+        process = subprocess.run(cmd, cwd=directory, stdin=p_in, stdout=p_out, stderr=p_error, universal_newlines=True)
 
     try:
         process.check_returncode()  # Will raise a CalledProcessError if return code != 0


### PR DESCRIPTION
The text parameter wasn't introduced until python 3.7, which causes an error for runSubprocess on 3.6. universal_newlines works for both. I would have sworn I already caught this. 