### PR TITLE
Allow runSubprocess to raise error instead of exiting

### DIFF
--- a/funannotate/aux_scripts/enrichment_parallel.py
+++ b/funannotate/aux_scripts/enrichment_parallel.py
@@ -73,4 +73,4 @@ if len(file_list) > args.cpus:
 else:
     procs = len(file_list)
 
-lib.runMultiNoProgress(GO_safe_run, file_list, procs)
+lib.runMultiProgress(GO_safe_run, file_list, procs, progress=False)

--- a/funannotate/aux_scripts/hmmer_parallel.py
+++ b/funannotate/aux_scripts/hmmer_parallel.py
@@ -54,7 +54,7 @@ def multiPFAMsearch(inputList, cpus, tmpdir, output):
     # input is a list of files, run multiprocessing on them
     pfam_results = os.path.join(os.path.dirname(tmpdir), 'pfam.txt')
     pfam_filtered = os.path.join(os.path.dirname(tmpdir), 'pfam.filtered.txt')
-    lib.runMultiNoProgress(safe_run, inputList, cpus)
+    lib.runMultiProgress(safe_run, inputList, cpus, progress=False)
 
     # now grab results and combine, kind of tricky as there are header and footers for each
     resultList = [os.path.join(tmpdir, f) for f in os.listdir(
@@ -105,7 +105,7 @@ def dbCANsearch(inputList, cpus, evalue, tmpdir, output):
     # run hmmerscan
     dbCAN_out = os.path.join(tmpdir, 'dbCAN.txt')
     dbCAN_filtered = os.path.join(tmpdir, 'dbCAN.filtered.txt')
-    lib.runMultiNoProgress(safe_run2, inputList, cpus)
+    lib.runMultiProgress(safe_run2, inputList, cpus, progress=False)
     # now grab results
     resultList = [os.path.join(tmpdir, f) for f in os.listdir(
         tmpdir) if os.path.isfile(os.path.join(tmpdir, f)) and f.endswith('.dbcan.txt')]

--- a/funannotate/aux_scripts/phobius-multiproc.py
+++ b/funannotate/aux_scripts/phobius-multiproc.py
@@ -51,7 +51,7 @@ def runPhobiusLocal(Input):
     base = base.split('.fa')[0]
     OUTPATH = os.path.join(TMPDIR, base+'.phobius')
     cmd = ['phobius.pl', '-short', Input]
-    lib.runSubprocess(cmd, TMPDIR, lib.log, capture_output=OUTPATH)
+    lib.runSubprocess(cmd, TMPDIR, lib.log, capture_output=OUTPATH, raise_not_exit=True)
 
 
 global parentdir

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -1268,7 +1268,7 @@ def runMultiProgress(function, inputList, cpus, progress=True):
                 except ValueError:
                     remaining += 1
             sys.stdout.write(f"     Progress: {completed} complete, {failed} failed, {remaining} remaining        \r")
-            if running == 0 and completed + failed == tasks:
+            if remaining == 0 and completed + failed == tasks:
                 sys.stdout.write("\n")
                 break
             time.sleep(1)

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -1268,7 +1268,7 @@ def runMultiProgress(function, inputList, cpus, progress=True):
                 except ValueError:
                     remaining += 1
             sys.stdout.write(f"     Progress: {completed} complete, {failed} failed, {remaining} remaining        \r")
-            if running == 0 and completed + failed = tasks:
+            if running == 0 and completed + failed == tasks:
                 sys.stdout.write("\n")
                 break
             time.sleep(1)

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -693,7 +693,8 @@ def process_handle(handle, mode="w"):
             output.close()
 
 
-def runSubprocess(cmd, directory, logfile, capture_output=True, capture_error=True, in_file=None, only_failed=False):
+def runSubprocess(cmd, directory, logfile, capture_output=True, capture_error=True, in_file=None, only_failed=False,
+                  raise_not_exit=False):
     """
     Runs a command using subprocess.run and directs output and stderr. If output or error are captured, they will be
     written to logfile.debug if the command succeeds, or logfile.error if the command fails.
@@ -713,6 +714,9 @@ def runSubprocess(cmd, directory, logfile, capture_output=True, capture_error=Tr
     :param only_failed: only write stdout/stderr to the logfile if the command fails (returns a non-zero exit status).
                        This only effects stdout/stderr if it's being captured (output/error == True)
     :type only_failed: bool
+    :param raise_not_exit: raise a subprocess.CalledProcessError if the subprocess fails, rather than sys.exit(1).
+                           Default is False
+    :type raise_not_exit: bool
     """
 
     def logoutput(logname, process_result):
@@ -733,7 +737,10 @@ def runSubprocess(cmd, directory, logfile, capture_output=True, capture_error=Tr
     except subprocess.CalledProcessError as e:
         logfile.error(f"CMD ERROR: {' '.join(cmd)}")
         logoutput(logfile.error, process)
-        sys.exit(1)  # this should probably be replaced with raise(e) and more messages
+        if raise_not_exit:
+            raise(e)
+        else:
+            sys.exit(1)  # this should probably be replaced with raise(e) and more messages
 
 
 def evmGFFvalidate(input, evmpath, logfile):
@@ -1251,24 +1258,20 @@ def runMultiProgress(function, inputList, cpus, progress=True):
     # refresh pbar every 5 seconds
     if progress:
         while True:
-            incomplete_count = sum(1 for x in results if not x.ready())
-            if incomplete_count == 0:
+            completed, failed, remaining = 0, 0, 0
+            for x in results:
+                try:
+                    if x.successful():
+                        completed += 1
+                    else:
+                        failed += 1
+                except ValueError:
+                    remaining += 1
+            sys.stdout.write(f"     Progress: {completed} complete, {failed} failed, {remaining} remaining        \r")
+            if running == 0 and completed + failed = tasks:
+                sys.stdout.write("\n")
                 break
-            sys.stdout.write("     Progress: %.2f%% \r" %
-                            (float(tasks - incomplete_count) / tasks * 100))
-            sys.stdout.flush()
             time.sleep(1)
-    p.close()
-    p.join()
-
-
-def runMultiNoProgress(function, inputList, cpus):
-    # setup pool
-    p = multiprocessing.Pool(cpus)
-    # setup results and split over cpus
-    results = []
-    for i in inputList:
-        results.append(p.apply_async(function, [i]))
     p.close()
     p.join()
 


### PR DESCRIPTION
Fix for issue #784 
Allow `runSubprocess` to raise an error instead of running `sys.exit(1)` by setting `raise_not_exit=True`. This can prevent the program from hanging if a subprocess has an error while being run as part of a multi-processing pool.
Remove the redundant function `runMultiNoProgress`, which can be handled by using `runMultiProgress` with `progress=False`.
Switch `iprscan-local.py` to use `runMultiProgress` from `funannotate.library`, instead of a redundant local copy of the function.

I think using `runSubprocess` with `raise_not_exit=True` can be used to replace a bunch of the `safe_run` functions in some of the auxiliary scripts, but I haven't had a chance to try that yet. 