### PR TITLE
improve check steps for version numbers

### DIFF
--- a/funannotate/check.py
+++ b/funannotate/check.py
@@ -125,12 +125,23 @@ def check_version2(name):
             m = re.match('emapper-(\S+)',vers)
             if m:
                 vers = m.group(1)
+        elif name == 'pigz':
+            (so,se) = subprocess.Popen(
+                [name, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
+            for str in (so,se):
+                m = re.match('pigz\s+(\S+)',str)
+                if m:
+                    vers = m.group(1)
+                    break
+        elif name == 'signalp':
+            vers = subprocess.Popen(
+                ['signalp6', '--version'], stdout=subprocess.PIPE, universal_newlines=True).communicate()[0]
         else:
             vers = subprocess.Popen(
                 [name, '--version'], stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].split('\n')[0]
         if 'exonerate' in vers:
             vers = vers.replace('exonerate from ', '')
-        if 'SignalP' in vers or 'pigz' in vers:
+        if 'SignalP' in vers:
             vers = vers.split(' ')[1]
         if 'AUGUSTUS' in vers:
             vers = vers.split(' is ')[0].replace('(', '').replace(')', '')
@@ -211,9 +222,13 @@ def check_version5(name):
                 [name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
             vers = 'no way to determine'
         elif name == 'fasta':
-            vers = subprocess.Popen(
-                [name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
-            vers = 'no way to determine'
+            (se,so) = subprocess.Popen(
+                [name,'-h'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
+            m = re.search(r'version:\s+(\S+)',so+se)
+            if m:
+                vers = m.group(1)
+            else:
+                vers = 'no way to determine'
         elif name == 'CodingQuarry':
             vers = subprocess.Popen(
                 [name], stdout=subprocess.PIPE, universal_newlines=True).communicate()

--- a/funannotate/check.py
+++ b/funannotate/check.py
@@ -130,7 +130,7 @@ def check_version2(name):
                 [name, '--version'], stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].split('\n')[0]
         if 'exonerate' in vers:
             vers = vers.replace('exonerate from ', '')
-        if 'SignalP' in vers:
+        if 'SignalP' in vers or 'pigz' in vers:
             vers = vers.split(' ')[1]
         if 'AUGUSTUS' in vers:
             vers = vers.split(' is ')[0].replace('(', '').replace(')', '')


### PR DESCRIPTION
- support `pigz --version` which returns output to stderr (centos, linux) and stdout (osx)
- support signalp6 explicit exe in the check_version2 script and proper parsing of version info
- parse fasta version number by passing in `fasta -h` as cmd and parsing `version: (\S+)`
- small documentation add to indicate that check_version7 is for signalp < 6.0