### PR TITLE
Fix checking for signalp6

### DIFF
--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -1028,7 +1028,7 @@ def main(args):
     if lib.which('signalp') or lib.checkannotations(signalp_out):
         if not lib.checkannotations(signalp_out):
             lib.log.info("Predicting secreted proteins with SignalP")
-            if os.path.exists(shutil.which('signalp6')) == True:
+            if not shutil.which('signalp6') == None:
                 lib.signalP6(Proteins, os.path.join(
                     outputdir, 'annotate_misc'), signalp_out, args.cpus)
             else:
@@ -1108,7 +1108,7 @@ def main(args):
         # results in dictClusters dictionary
         dictClusters = lib.GetClusterGenes(AntiSmashBed, GFF, Scaffolds,
                                            Cluster_annotations)
-        
+
         # Imperfect solution to make sure each AntiSMASH cluster has a different number
         if args.renumber_antismash:
             with open(Cluster_annotations, 'r') as ascl:

--- a/funannotate/check.py
+++ b/funannotate/check.py
@@ -366,7 +366,7 @@ def main(args):
     programs5 = ['gmes_petap.pl', 'blat', 'pslCDnaFilter', 'fasta',
                  'CodingQuarry', 'snap', 'glimmerhmm']  # no version option at all, a$$holes
     programs6 = ['hmmsearch', 'hmmscan', 'tRNAscan-SE']  # -h
-    if not shutil.which('signalp6')) == None:
+    if not shutil.which('signalp6') == None:
         programs7 = ['signalp']  # -V
     else:
         programs7 = []  # -V

--- a/funannotate/check.py
+++ b/funannotate/check.py
@@ -334,7 +334,7 @@ def get_version(program):
     elif program in ['hmmsearch', 'hmmscan', 'tRNAscan-SE']:
         checker = check_version6
     elif program in ['signalp']:
-        if os.path.exists(shutil.which('signalp6')) == True:
+        if not shutil.which('signalp6') == None:
             checker = check_version2
         else:
             checker = check_version7
@@ -359,14 +359,14 @@ def main(args):
                  'tbl2asn', 'emapper.py', 'minimap2', 'mafft',
                  'trimal', 'stringtie', 'salmon', 'proteinortho', 'tantan',
                  'pigz']  # --version
-    if os.path.exists(shutil.which('signalp6')) == True:
+    if not shutil.which('signalp6') == None:
         programs2.append('signalp')
     programs3 = []  # -v
     programs4 = ['diamond', 'ete3', 'kallisto']  # version
     programs5 = ['gmes_petap.pl', 'blat', 'pslCDnaFilter', 'fasta',
                  'CodingQuarry', 'snap', 'glimmerhmm']  # no version option at all, a$$holes
     programs6 = ['hmmsearch', 'hmmscan', 'tRNAscan-SE']  # -h
-    if os.path.exists(shutil.which('signalp6')) == False:
+    if not shutil.which('signalp6')) == None:
         programs7 = ['signalp']  # -V
     else:
         programs7 = []  # -V


### PR DESCRIPTION
The check command `os.path.exists(shut.which('signalp6')) == True` in *check.py* and *annotate.py* gave error when signalp6 not found `TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType`.

For example:
```
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:04:10) 
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> import shutil
>>> os.path.exists(shutil.which('signalp6'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ecoevo10/anaconda3/envs/funannotate/lib/python3.8/genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
>>> os.path.exists(shutil.which('signalp'))
True
>>> shutil.which('signalp6')
>>> shutil.which('signalp6') == None
True
```

This PR fixed the issue #833