### PR TITLE
Fix compatibility issue with pandas >=2

### DIFF
--- a/funannotate/compare.py
+++ b/funannotate/compare.py
@@ -966,7 +966,7 @@ def main(args):
                     if goresult[0]:
                         # the get header row from tuple
                         df = pd.read_csv(file, sep="\t", skiprows=goresult[1])
-                        df.columns = df.columns.str.replace(r"^# ", "")
+                        df.columns = df.columns.str.replace(r"^# ", "", regex=True)
                         df["enrichment"].replace("p", "under", inplace=True)
                         df["enrichment"].replace("e", "over", inplace=True)
                         df2 = df.loc[df["p_fdr"] < args.go_fdr]


### PR DESCRIPTION
While testing funannotate compare 1.8.15 in a freshly installed conda env, I got this error:

```
[Apr 25 03:14 PM]: Summarizing fungal transcription factors
[Apr 25 03:14 PM]: Running GO enrichment for each genome
Traceback (most recent call last):
  File "/_conda/envs/__funannotate@1.8.15/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3652, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 147, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 176, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7080, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7088, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'GO'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/_conda/envs/__funannotate@1.8.15/bin/funannotate", line 10, in <module>
    sys.exit(main())
  File "/_conda/envs/__funannotate@1.8.15/lib/python3.8/site-packages/funannotate/funannotate.py", line 716, in main
    mod.main(arguments)
  File "/_conda/envs/__funannotate@1.8.15/lib/python3.8/site-packages/funannotate/compare.py", line 986, in main
    + df2["GO"].astype(str)
  File "/_conda/envs/__funannotate@1.8.15/lib/python3.8/site-packages/pandas/core/frame.py", line 3760, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/_conda/envs/__funannotate@1.8.15/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3654, in get_loc
    raise KeyError(key) from err
KeyError: 'GO'
```

After some debugging, I found out that it comes from a [breaking change in pandas2](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html)

> Change the default argument of regex for [Series.str.replace()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.str.replace.html#pandas.Series.str.replace) from True to False. Additionally, a single character pat with regex=True is now treated as a regular expression instead of a string literal. ([GH36695](https://github.com/pandas-dev/pandas/issues/36695), [GH24804](https://github.com/pandas-dev/pandas/issues/24804))

Here's a PR that always set the regex param to True, so it should work whatever pandas version is installed