### PR TITLE
Update funannotate-p2g.py for contig_expand to use int

### DIFF
--- a/funannotate/aux_scripts/funannotate-p2g.py
+++ b/funannotate/aux_scripts/funannotate-p2g.py
@@ -33,7 +33,7 @@ parser.add_argument('-o', '--out', required=True,
                     help='Final exonerate output file')
 parser.add_argument('-t', '--tblastn_out', help='Save tblastn output')
 parser.add_argument('--maxintron', default=3000, help='Maximum intron size')
-parser.add_argument('--contig_expand', default=3000, help='number of basepairs to expand from tblastn/diamond alignments, to allow exonerate to find the target despite imprecise alignments')
+parser.add_argument('--contig_expand', default=3000, type=int, help='number of basepairs to expand from tblastn/diamond alignments, to allow exonerate to find the target despite imprecise alignments')
 parser.add_argument('--exonerate_pident', default=80,
                     help='Exonerate pct identity')
 parser.add_argument('--logfile', default='funannotate-p2g.log', help='logfile')


### PR DESCRIPTION
Mea culpa, I didn't actually test my previous PR until just now, and immediately ran into this rookie mistake. This PR fixes it.

I've also run into some other bugs in `funannotate-p2g.py` with issues if you have a colon `:` in the FASTA record id for the protein queries. Will try to work on a PR to report / correct for that edge case as well.

Can I get a brief pointer on how you are implemented tests in this repo? I've never actually done tests, but, figure it is time to learn as formal unit tests would have caught my rookie mistake :) 

```
conda_env_linux-64/lib/python3.9/site-packages/funannotate/aux_scripts/funannotate-p2g.py", line 309, in <module>
    start = x[1] - args.contig_expand
TypeError: unsupported operand type(s) for -: 'int' and 'str'
```