### PR TITLE
update MEROPS release filename is now 'meropsscan.lib' per issue #1054

### DIFF
--- a/funannotate/resources.py
+++ b/funannotate/resources.py
@@ -196,7 +196,7 @@ COGS = {
 DBURL = {
     "uniprot": "https://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz",
     "uniprot-release": "https://ftp.ebi.ac.uk/pub/databases/uniprot/current_release/knowledgebase/complete/reldate.txt",
-    "merops": "https://ftp.ebi.ac.uk/pub/databases/merops/current_release/merops_scan.lib",
+    "merops": "https://ftp.ebi.ac.uk/pub/databases/merops/current_release/meropsscan.lib",
     "dbCAN": "https://bcb.unl.edu/dbCAN2/download/Databases/V11/dbCAN-HMMdb-V11.txt",
     "dbCAN-tsv": "https://bcb.unl.edu/dbCAN2/download/Databases/V11/CAZyDB.08062022.fam-activities.txt",
     "dbCAN-log": "https://bcb.unl.edu/dbCAN2/download/Databases/V11/readme.txt",

--- a/funannotate/setupDB.py
+++ b/funannotate/setupDB.py
@@ -138,7 +138,7 @@ def wget(url, name):
 
 
 def meropsDB(info, force=False, args={}):
-    fasta = os.path.join(FUNDB, 'merops_scan.lib')
+    fasta = os.path.join(FUNDB, 'meropsscan.lib')
     filtered = os.path.join(FUNDB, 'merops.formatted.fa')
     database = os.path.join(FUNDB, 'merops.dmnd')
     if os.path.isfile(fasta) and args.update and not force:


### PR DESCRIPTION
Jon I added this fix which points to new release file name URL for MEROPS.  Assume it can be merged - if you have unit test for this we can check or I'll do it on a local system when I get a chance.