### PR TITLE
Update tutorials.rst

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -43,7 +43,7 @@ For this walkthrough, lets assume you have stranded RNA-seq data from 3 differen
 
 .. code-block:: none
 
-    funannotate sort -i Spades.genome.cleaned.fa -b scaffold -o Spades.genome.cleaned.sorted.fa
+    funannotate sort --minlen 1 -i Spades.genome.cleaned.fa -b scaffold -o Spades.genome.cleaned.sorted.fa
     
 
 3. Now we want to softmask the repetitive elements in the assembly.


### PR DESCRIPTION
The current instructions for `funannotate sort` in the tutorial throw the following error:

```sh
funannotate sort -i cleaned.fa -b scaffold -o sorted.fa
88 contigs records loaded
Sorting and renaming contig headers
Traceback (most recent call last):
  File "/home/intelliyeast/micromamba/envs/funannotate/bin/funannotate", line 10, in <module>
    sys.exit(main())
  File "/home/intelliyeast/micromamba/envs/funannotate/lib/python3.8/site-packages/funannotate/funannotate.py", line 717, in main
    mod.main(arguments)
  File "/home/intelliyeast/micromamba/envs/funannotate/lib/python3.8/site-packages/funannotate/sort.py", line 80, in main
    SortRenameHeaders(
  File "/home/intelliyeast/micromamba/envs/funannotate/lib/python3.8/site-packages/funannotate/sort.py", line 37, in SortRenameHeaders
    if minlen > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

This is because the minlen variable is not being set currently. Therefore, the current version of the code necessitates`--minlen 1` argument.