### PR TITLE
SafeRemove trainingdir

### DIFF
--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -11069,7 +11069,7 @@ def trainAugustus(
                 train_table = print_table(trainTable, return_str=True)
                 sys.stderr.write(train_table)
                 # clean up tmp folder
-                shutil.rmtree(trainingdir)
+                SafeRemove(trainingdir)
             else:
                 if train_results[4] < 0.50:
                     log.info(


### PR DESCRIPTION
Hello! I'm getting this error with *some* funannotate runs but not others. Not sure why Augustus doesn't always create the `trainingdir`, but I thought using the SafeRemove helper could be an easy workaround?

Cheers!

```
...
[Jan 20 01:45 AM]: Running BUSCO to find conserved gene models for training ab-initio predictors
[Jan 20 02:57 AM]: 5,753 valid BUSCO predictions found, validating protein sequences
[Jan 20 03:03 AM]: 5,705 BUSCO predictions validated
[Jan 20 03:03 AM]: Training Augustus using BUSCO gene models
[Jan 20 03:05 AM]: Augustus initial training results:
  Feature       Specificity   Sensitivity
  nucleotides   96.5%         93.2%      
  exons         78.0%         83.6%      
  genes         38.9%         32.7%      
[Jan 20 03:07 AM]: Augustus optimized training results:
  Feature       Specificity   Sensitivity
  nucleotides   96.5%         93.2%      
  exons         78.0%         83.6%      
  genes         38.9%         32.7%      
Traceback (most recent call last):
  File "/usr/local/bin/funannotate", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/funannotate/funannotate.py", line 717, in main
    mod.main(arguments)
  File "/usr/local/lib/python3.11/site-packages/funannotate/predict.py", line 2094, in main
    lib.trainAugustus(
  File "/usr/local/lib/python3.11/site-packages/funannotate/library.py", line 11070, in trainAugustus
    shutil.rmtree(trainingdir)
  File "/usr/local/lib/python3.11/shutil.py", line 742, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/local/lib/python3.11/shutil.py", line 740, in rmtree
    orig_st = os.lstat(path, dir_fd=dir_fd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'path/to/results/funannotate/predict_misc/tmp_opt_myspecies'
...
```