### PR TITLE
add Gzip support for .xml files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -199,7 +199,7 @@ revised to align with the
 
 *Single terms (NCBI "eliminate entirely" list):*
 `novel`, `fragment`, `partial`, `truncated`, `dubious`, `doubtful`, `expressed`,
-`secreted`, `WGS`, `ORF`, `GO`, `related`
+`secreted`, `WGS`, `ORF`, `GO`
 
 *`conserved` as standalone qualifier* — removed unless immediately followed by `domain`
 (negative lookahead `(?!\s+domain)` preserves "conserved domain-containing protein").

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -272,18 +272,18 @@ anchors so substitutions only fire on whole words.
 - Rewrote the product-name cleaning block to use `\b`-bounded patterns; the old
   `re.escape(k)` dict lookup trick is removed in favour of sequential `_pat.sub()` calls.
 
-### New flag: `--allow_ec_without_gene` in `funannotate annotate`
+### New flag: `--allow_ec_without_genename` in `funannotate annotate`
 
 `tbl2asn` rejects an `EC_number` qualifier on a CDS that has no `gene` qualifier (i.e.
 no gene name was assigned). By default funannotate now suppresses EC_number output for
 any gene model that did not receive a gene-name annotation from UniProt or EggNog.
 
-Pass `--allow_ec_without_gene` to restore the previous behaviour and write EC numbers
+Pass `--allow_ec_without_genename` to restore the previous behaviour and write EC numbers
 regardless of gene-name assignment.
 
 **`funannotate/annotate.py`**
-- Added `--allow_ec_without_gene` flag (default off).
-- `lib.updateTBL()` is called with `require_gene_for_ec=not args.allow_ec_without_gene`.
+- Added `--allow_ec_without_genename` flag (default off).
+- `lib.updateTBL()` is called with `require_gene_for_ec=not args.allow_ec_without_genename`.
 
 **`funannotate/library.py`** (`updateTBL`)
 - Added `require_gene_for_ec=True` keyword argument.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,66 @@ wheel.  The `_version.txt` fallback described in earlier CHANGES was never imple
 - Added `package_data={"funannotate": ["_version.txt"]}` so the file is included in
   eggs and wheels.
 
+### Feature: IPRscan XML and UniProt BLAST XML automatically compressed after use
+
+Large intermediate XML files are now gzip-compressed in place after they are fully
+consumed, reducing disk usage in `annotate_misc/`.  Subsequent runs detect the `.gz`
+cache and skip re-running the expensive tools.
+
+**`funannotate/annotate.py`** (`SwissProtBlast`)
+- After parsing `uniprot.xml`, the plain file is compressed to `uniprot.xml.gz` and
+  removed.  The existing `.gz` cache check (from the previous feature) means diamond
+  is not re-run if `uniprot.xml.gz` already exists.
+
+**`funannotate/annotate.py`** (IPRscan block)
+- After `iprscan2annotations.py` runs, `iprscan.xml` is compressed to `iprscan.xml.gz`
+  and removed (skipped when the input was already a user-supplied `.gz` file).
+- On subsequent runs with no `--iprscan` argument, the block now checks for
+  `iprscan.xml.gz` if the plain `iprscan.xml` is absent, so parsing is not repeated.
+
+### Feature: IPRscan XML and UniProt BLAST XML support gzip-compressed files
+
+**IPRscan XML (`--iprscan`)**
+
+`funannotate/aux_scripts/iprscan2annotations.py` opened the XML with plain `open()`,
+rejecting `.gz` inputs.  `annotate.py` copied the file to `iprscan.xml` before parsing,
+so pre-computed `.gz` results also couldn't be passed directly.
+
+- `iprscan2annotations.py`: added `import gzip`; the XML file is now opened with
+  `gzip.open(..., "rt")` when the path ends in `.gz`, plain `open()` otherwise.
+- `annotate.py` (`--iprscan`): when the supplied file ends in `.gz`, `IPRCombined` is
+  pointed directly at the source (no copy step), so `iprscan2annotations.py` receives
+  the `.gz` path and decompresses on the fly.  Also fixed the `samefile` guard to
+  pre-check `os.path.isfile` so it doesn't raise `FileNotFoundError` on a first run.
+
+**UniProt BLAST XML (`uniprot.xml`)**
+
+`SwissProtBlast` in `annotate.py` cached blast results to `uniprot.xml` and re-read
+them with plain `open()`.  If the cached file was manually compressed to `uniprot.xml.gz`
+to save space, the cache was missed and blast was re-run.
+
+- The cache check now also looks for `uniprot.xml.gz`; if found, blast is skipped.
+- The result file is opened with `gzip.open(..., "rt")` when `.gz` is present, plain
+  `open()` otherwise, so `SearchIO.parse` receives a text stream in both cases.
+
+### Feature: `--antismash` accepts gzip-compressed input (`.gbk.gz`)
+
+`ParseAntiSmash` and `antismash_version` in `funannotate/library.py` previously opened
+the antiSMASH GenBank file with `open(..., "r")`, rejecting compressed inputs.
+
+**`funannotate/library.py`**
+- Added `_open_maybe_gzip(path, mode)` helper: returns `gzip.open(path, "rt")` for
+  `.gz` paths and plain `open(path, mode)` otherwise.
+- `antismash_version` and `ParseAntiSmash` now call `_open_maybe_gzip` instead of
+  `open`, so both `.gbk` and `.gbk.gz` inputs are handled transparently.
+
+**`funannotate/annotate.py`**
+- When `--antismash` is a `.gz` file, `antismash_input` is set to the supplied path
+  directly (no copy/decompression step needed since parsing is now gzip-aware).
+- Also fixed the `os.path.samefile` guard to pre-check `os.path.isfile(antismash_input)`
+  so it does not raise `FileNotFoundError` on a first run when the destination doesn't
+  exist yet.
+
 ### Fix: `SameFileError` when `--signalp/--phobius/--eggnog/--iprscan/--antismash` points to the existing output file
 
 `shutil.copyfile(src, dst)` raises `SameFileError` when src and dst resolve to the same

--- a/funannotate/__version__.py
+++ b/funannotate/__version__.py
@@ -16,7 +16,7 @@ def _git_version():
     """
     try:
         here = os.path.dirname(os.path.abspath(__file__))
-        if not os.path.isdir(os.path.join(here, "..", ".git")):
+        if not os.path.exists(os.path.join(here, "..", ".git")):
             version_txt = os.path.join(here, "_version.txt")
             if os.path.isfile(version_txt):
                 with open(version_txt) as _f:

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -1370,7 +1370,9 @@ def main(args):
                 )
                 GeneProduct = _new
         if GeneProduct != _prod_before:
-            lib.log.debug("product_clean [%s] -> [%s] after subs: %r", _prod_before, k, GeneProduct)
+            lib.log.debug(
+                "product_clean [%s] after subs: %r => %r", k, _prod_before, GeneProduct
+            )
         # if gene name in product, convert to lowercase
         if GeneName in GeneProduct:
             _before = GeneProduct

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -209,7 +209,7 @@ def morethanXnumbers(s, num):
 
 
 def capfirst(x):
-    return x[0].upper() + x[1:]
+    return x[0].upper() + x[1:] if x else x
 
 
 def item2index(inputList, item):
@@ -1209,6 +1209,133 @@ def main(args):
         r")"
     )
 
+    # Clean the product name to comply with NCBI International Protein Nomenclature
+    # Guidelines (https://www.ncbi.nlm.nih.gov/genbank/internatprot_nomenguide/).
+    #
+    # Rules are applied in order; multi-word phrases appear before single words so
+    # that compound patterns are matched before their component words are removed.
+    # \b anchors prevent matching substrings of longer words (e.g. "biogenesis",
+    # "frameshift", "homologous", "ECM").
+    #
+    # Key policy decisions reflected here:
+    #   - "uncharacterized protein" is a valid NCBI product name; only British
+    #     spelling is normalised — it is NOT converted to "putative".
+    #   - "X family protein" is a valid NCBI format; the \bfamily\b removal rule
+    #     has been dropped.
+    #   - homolog/homologue/ortholog patterns now consume the trailing "to/of" so
+    #     that descriptions like "Homolog to Saccharomyces cerevisiae gds1" do not
+    #     leave a dangling "to Saccharomyces cerevisiae gds1".
+    #   - "inactivated" → "inactive" per NCBI (reserve for altered catalytic
+    #     residues only).
+    #   - "gene" → "protein" only when terminal to avoid corrupting phrases like
+    #     "gene expression regulator".
+    product_substitutions = [
+        # --- uncertainty qualifiers (NCBI: eliminate potential/possible/probable/predicted) ---
+        (re.compile(r"\bpotential\b", re.I), "putative"),
+        (re.compile(r"\bpossible\b", re.I), "putative"),
+        (re.compile(r"\bprobable\b", re.I), "putative"),
+        (re.compile(r"\bpredicted\b", re.I), "putative"),
+        # standardise British spelling; "uncharacterized protein" is valid per NCBI
+        (re.compile(r"\buncharacterised\b", re.I), "uncharacterized"),
+        # --- homolog/ortholog/similar + known organism + gene → "Protein <gene>" ---
+        # Matches "Homolog(ous) to Saccharomyces cerevisiae gpr1" → "Protein gpr1".
+        # The gene token is the first non-space word after the organism name.
+        # These full-capture patterns must appear BEFORE the bare-removal fallbacks.
+        (
+            re.compile(
+                r"\bhomolog(?:ous|ues?|s)?\s+(?:to|of)\s+"
+                + _MODEL_ORGS
+                + r"\s+(\S+)",
+                re.I,
+            ),
+            r"Protein \1",
+        ),
+        (
+            re.compile(
+                r"\bortholog(?:ous|ues?|s)?\s+(?:to|of)\s+"
+                + _MODEL_ORGS
+                + r"\s+(\S+)",
+                re.I,
+            ),
+            r"Protein \1",
+        ),
+        (re.compile(r"\bsimilar to\s+" + _MODEL_ORGS + r"\s+(\S+)", re.I), r"Protein \1"),
+        # --- homolog/ortholog fallbacks (unknown organism or no gene token) ---
+        # Phrase form: consume "homolog(ous)/ortholog(ous) to/of <whatever>" entirely
+        (re.compile(r"\bhomolog(?:ous|ues?|s)?\s+(?:to|of)\s+", re.I), ""),
+        (re.compile(r"\bortholog(?:ous|ues?|s)?\s+(?:to|of)\s+", re.I), ""),
+        # Bare form: remove homolog/homologue/homologs but NOT "homologous" alone —
+        # "homologous recombination" is a valid biological term and must be preserved.
+        # Same logic for ortholog.
+        (re.compile(r"\bhomolog(?:ues?|s)?\b", re.I), ""),
+        (re.compile(r"\bortholog(?:ues?|s)?\b", re.I), ""),
+        (re.compile(r"\bsimilar to\b", re.I), ""),
+        # --- organism references (NCBI: avoid organism-specific characteristics) ---
+        # Named model organisms stripped if not already consumed by capture patterns above
+        (re.compile(_MODEL_ORGS, re.I), ""),
+        (re.compile(r"\byeast\b", re.I), ""),
+        (re.compile(r"\bhuman\b", re.I), ""),
+        (re.compile(r"\bmurine\b", re.I), ""),
+        (re.compile(r"\bmouse\b", re.I), ""),
+        (re.compile(r"\bDrosophila\b", re.I), ""),
+        # --- NCBI "eliminate entirely" terms ---
+        (re.compile(r"\bnovel\b", re.I), ""),
+        (re.compile(r"\bfragment\b", re.I), ""),
+        (re.compile(r"\bpartial\b", re.I), ""),
+        (re.compile(r"\btruncated\b", re.I), ""),
+        (re.compile(r"\bdubious\b", re.I), ""),
+        (re.compile(r"\bdoubtful\b", re.I), ""),
+        (re.compile(r"\bexpressed\b", re.I), ""),
+        (re.compile(r"\bsecreted\b", re.I), ""),
+        (re.compile(r"\bWGS\b"), ""),
+        (re.compile(r"\bORF\b"), ""),
+        # "conserved" as a standalone qualifier only; preserve "conserved domain"
+        (re.compile(r"\bconserved\b(?!\s+domain)", re.I), ""),
+        # --- NCBI "eliminate" phrases (multi-word first) ---
+        (re.compile(r"\bprotein of unknown function\b", re.I), "hypothetical protein"),
+        (re.compile(r"\bconserved hypothetical\b", re.I), ""),
+        (re.compile(r"\bhypothetical conserved\b", re.I), ""),
+        (re.compile(r"\bcell surface\b", re.I), ""),
+        (re.compile(r"\bsurface antigen\b", re.I), ""),
+        (re.compile(r"\binvolved in\b", re.I), ""),
+        (re.compile(r"\bimplicated in\b", re.I), ""),
+        (re.compile(r"\balso known as\b", re.I), ""),
+        (re.compile(r"\bopen reading frame\b", re.I), ""),
+        # --- NCBI: "inactivated" → "inactive" (reserve for altered catalytic residues) ---
+        (re.compile(r"\binactivated\b", re.I), "inactive"),
+        # --- NCBI: database/ontology IDs are prohibited as product names ---
+        (re.compile(r"\bEC(\s(\S+))?\b"), ""),
+        (re.compile(r"\bCOG\b"), ""),
+        (re.compile(r"\bGO\b"), ""),
+        # --- structural/annotation noise ---
+        (re.compile(r"\binterrupt\b", re.I), ""),
+        (re.compile(r"\bframe ?shift\b", re.I), ""),
+        # (re.compile(r"\brelated\b", re.I), ""), # this seems not needed
+        # "gene" → "protein" only when terminal; avoids "gene expression" → "protein expression"
+        (re.compile(r"\bgene\b\s*$", re.I), "protein"),
+        # "family" retained: "X family protein" is a valid NCBI format
+        # --- post-substitution cleanup ---
+        # strip leading prepositions left by removals (e.g. homolog stripped → "to Saccharomyces")
+        (re.compile(r"^\s*(?:to|of|by|with|from|for)\s+", re.I), ""),
+        # collapse "protein protein" introduced by multiple substitutions
+        (re.compile(r"\bprotein\s+protein\b", re.I), "protein"),
+        # "-ase protein" is redundant per NCBI (enzyme names need no trailing "protein")
+        (re.compile(r"\b(\w+ase)\s+protein\b", re.I), r"\1"),
+        # --- NCBI: Greek letters spelled out in lowercase ---
+        (re.compile(r"\bAlpha\b"), "alpha"),
+        (re.compile(r"\bBeta\b"), "beta"),
+        (re.compile(r"\bGamma\b"), "gamma"),
+        (re.compile(r"\bKappa\b"), "kappa"),
+        (re.compile(r"\bSigma\b"), "sigma"),
+        # Delta intentionally omitted: capitalised in steroid/fatty acid formal names
+        # --- NCBI: Arabic numerals preferred over informal Roman numerals ---
+        # Exceptions such as "RNA polymerase II" are established names — not converted
+        (re.compile(r"\btype I\b"), "type 1"),
+        (re.compile(r"\btype II\b"), "type 2"),
+        (re.compile(r"\btype III\b"), "type 3"),
+        (re.compile(r"\btype IV\b"), "type 4"),
+    ]
+
     GeneSeen = {}
     NeedCurating = {}
     NotInCurated = {}
@@ -1232,130 +1359,9 @@ def main(args):
             thenots.append(GeneName)
             # if not GeneName in NotInCurated:
             #    NotInCurated[GeneName] = GeneProduct
-        # Clean the product name to comply with NCBI International Protein Nomenclature
-        # Guidelines (https://www.ncbi.nlm.nih.gov/genbank/internatprot_nomenguide/).
-        #
-        # Rules are applied in order; multi-word phrases appear before single words so
-        # that compound patterns are matched before their component words are removed.
-        # \b anchors prevent matching substrings of longer words (e.g. "biogenesis",
-        # "frameshift", "homologous", "ECM").
-        #
-        # Key policy decisions reflected here:
-        #   - "uncharacterized protein" is a valid NCBI product name; only British
-        #     spelling is normalised — it is NOT converted to "putative".
-        #   - "X family protein" is a valid NCBI format; the \bfamily\b removal rule
-        #     has been dropped.
-        #   - homolog/homologue/ortholog patterns now consume the trailing "to/of" so
-        #     that descriptions like "Homolog to Saccharomyces cerevisiae gds1" do not
-        #     leave a dangling "to Saccharomyces cerevisiae gds1".
-        #   - "inactivated" → "inactive" per NCBI (reserve for altered catalytic
-        #     residues only).
-        #   - "gene" → "protein" only when terminal to avoid corrupting phrases like
-        #     "gene expression regulator".
-        rep = [
-            # --- uncertainty qualifiers (NCBI: eliminate potential/possible/probable/predicted) ---
-            (re.compile(r"\bpotential\b",   re.I), "putative"),
-            (re.compile(r"\bpossible\b",    re.I), "putative"),
-            (re.compile(r"\bprobable\b",    re.I), "putative"),
-            (re.compile(r"\bpredicted\b",   re.I), "putative"),
-            # standardise British spelling; "uncharacterized protein" is valid per NCBI
-            (re.compile(r"\buncharacterised\b", re.I), "uncharacterized"),
-
-            # --- homolog/ortholog/similar + known organism + gene → "Protein <gene>" ---
-            # Matches "Homolog(ous) to Saccharomyces cerevisiae gpr1" → "Protein gpr1".
-            # The gene token is the first non-space word after the organism name.
-            # These full-capture patterns must appear BEFORE the bare-removal fallbacks.
-            (re.compile(r"\bhomolog(?:ous|ues?|s)?\s+(?:to|of)\s+" + _MODEL_ORGS + r"\s+(\S+)", re.I), r"Protein \1"),
-            (re.compile(r"\bortholog(?:ous|ues?|s)?\s+(?:to|of)\s+" + _MODEL_ORGS + r"\s+(\S+)", re.I), r"Protein \1"),
-            (re.compile(r"\bsimilar to\s+" + _MODEL_ORGS + r"\s+(\S+)", re.I), r"Protein \1"),
-
-            # --- homolog/ortholog fallbacks (unknown organism or no gene token) ---
-            # Phrase form: consume "homolog(ous)/ortholog(ous) to/of <whatever>" entirely
-            (re.compile(r"\bhomolog(?:ous|ues?|s)?\s+(?:to|of)\s+", re.I), ""),
-            (re.compile(r"\bortholog(?:ous|ues?|s)?\s+(?:to|of)\s+", re.I), ""),
-            # Bare form: remove homolog/homologue/homologs but NOT "homologous" alone —
-            # "homologous recombination" is a valid biological term and must be preserved.
-            # Same logic for ortholog.
-            (re.compile(r"\bhomolog(?:ues?|s)?\b",  re.I), ""),
-            (re.compile(r"\bortholog(?:ues?|s)?\b", re.I), ""),
-            (re.compile(r"\bsimilar to\b",           re.I), ""),
-
-            # --- organism references (NCBI: avoid organism-specific characteristics) ---
-            # Named model organisms stripped if not already consumed by capture patterns above
-            (re.compile(_MODEL_ORGS, re.I), ""),
-            (re.compile(r"\byeast\b",      re.I), ""),
-            (re.compile(r"\bhuman\b",      re.I), ""),
-            (re.compile(r"\bmurine\b",     re.I), ""),
-            (re.compile(r"\bmouse\b",      re.I), ""),
-            (re.compile(r"\bDrosophila\b", re.I), ""),
-
-            # --- NCBI "eliminate entirely" terms ---
-            (re.compile(r"\bnovel\b",      re.I), ""),
-            (re.compile(r"\bfragment\b",   re.I), ""),
-            (re.compile(r"\bpartial\b",    re.I), ""),
-            (re.compile(r"\btruncated\b",  re.I), ""),
-            (re.compile(r"\bdubious\b",    re.I), ""),
-            (re.compile(r"\bdoubtful\b",   re.I), ""),
-            (re.compile(r"\bexpressed\b",  re.I), ""),
-            (re.compile(r"\bsecreted\b",   re.I), ""),
-            (re.compile(r"\bWGS\b"),               ""),
-            (re.compile(r"\bORF\b"),               ""),
-            # "conserved" as a standalone qualifier only; preserve "conserved domain"
-            (re.compile(r"\bconserved\b(?!\s+domain)", re.I), ""),
-
-            # --- NCBI "eliminate" phrases (multi-word first) ---
-            (re.compile(r"\bprotein of unknown function\b", re.I), "hypothetical protein"),
-            (re.compile(r"\bconserved hypothetical\b",      re.I), ""),
-            (re.compile(r"\bhypothetical conserved\b",      re.I), ""),
-            (re.compile(r"\bcell surface\b",                re.I), ""),
-            (re.compile(r"\bsurface antigen\b",             re.I), ""),
-            (re.compile(r"\binvolved in\b",                 re.I), ""),
-            (re.compile(r"\bimplicated in\b",               re.I), ""),
-            (re.compile(r"\balso known as\b",               re.I), ""),
-            (re.compile(r"\bopen reading frame\b",          re.I), ""),
-
-            # --- NCBI: "inactivated" → "inactive" (reserve for altered catalytic residues) ---
-            (re.compile(r"\binactivated\b", re.I), "inactive"),
-
-            # --- NCBI: database/ontology IDs are prohibited as product names ---
-            (re.compile(r"\bEC(\s(\S+))?\b"),  ""),
-            (re.compile(r"\bCOG\b"), ""),
-            (re.compile(r"\bGO\b"),  ""),
-
-            # --- structural/annotation noise ---
-            (re.compile(r"\binterrupt\b",   re.I), ""),
-            (re.compile(r"\bframe ?shift\b",   re.I), ""),
-            # (re.compile(r"\brelated\b", re.I), ""), # this seems not needed
-            # "gene" → "protein" only when terminal; avoids "gene expression" → "protein expression"
-            (re.compile(r"\bgene\b\s*$", re.I), "protein"),
-            # "family" retained: "X family protein" is a valid NCBI format
-
-            # --- post-substitution cleanup ---
-            # strip leading prepositions left by removals (e.g. homolog stripped → "to Saccharomyces")
-            (re.compile(r"^\s*(?:to|of|by|with|from|for)\s+", re.I), ""),
-            # collapse "protein protein" introduced by multiple substitutions
-            (re.compile(r"\bprotein\s+protein\b", re.I), "protein"),
-            # "-ase protein" is redundant per NCBI (enzyme names need no trailing "protein")
-            (re.compile(r"\b(\w+ase)\s+protein\b", re.I), r"\1"),
-
-            # --- NCBI: Greek letters spelled out in lowercase ---
-            (re.compile(r"\bAlpha\b"), "alpha"),
-            (re.compile(r"\bBeta\b"),  "beta"),
-            (re.compile(r"\bGamma\b"), "gamma"),
-            (re.compile(r"\bKappa\b"), "kappa"),
-            (re.compile(r"\bSigma\b"), "sigma"),
-            # Delta intentionally omitted: capitalised in steroid/fatty acid formal names
-
-            # --- NCBI: Arabic numerals preferred over informal Roman numerals ---
-            # Exceptions such as "RNA polymerase II" are established names — not converted
-            (re.compile(r"\btype I\b"),   "type 1"),
-            (re.compile(r"\btype II\b"),  "type 2"),
-            (re.compile(r"\btype III\b"), "type 3"),
-            (re.compile(r"\btype IV\b"),  "type 4"),
-        ]
         _prod_before = GeneProduct
         lib.log.debug("product_clean [%s] raw: %r", k, GeneProduct)
-        for _pat, _repl in rep:
+        for _pat, _repl in product_substitutions:
             _new = _pat.sub(_repl, GeneProduct)
             if _new != GeneProduct:
                 lib.log.debug(

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -7,6 +7,7 @@ from funannotate.aux_scripts.fasta2agp import parse_scaffolds_makeagp
 import sys
 import os
 import subprocess
+import gzip
 import shutil
 import argparse
 import re
@@ -123,12 +124,14 @@ def SwissProtBlast(input, cpus, evalue, tmpdir, GeneDict, diamond=True):
             "-query",
             input,
         ]
-    if not lib.checkannotations(blast_tmp):
+    blast_tmp_gz = blast_tmp + ".gz"
+    if not lib.checkannotations(blast_tmp) and not os.path.isfile(blast_tmp_gz):
         lib.runSubprocess(cmd, ".", lib.log, only_failed=True)
-    # parse results
+    # parse results — support a gzip-compressed cached copy
     counter = 0
     total = 0
-    with open(blast_tmp, "r") as results:
+    _opener = gzip.open(blast_tmp_gz, "rt") if os.path.isfile(blast_tmp_gz) else open(blast_tmp, "r")
+    with _opener as results:
         for qresult in SearchIO.parse(results, "blast-xml"):
             hits = qresult.hits
             qlen = qresult.seq_len
@@ -183,6 +186,11 @@ def SwissProtBlast(input, cpus, evalue, tmpdir, GeneDict, diamond=True):
                             }
                         )
     lib.log.info(f"{counter:,} valid gene/product annotations from {total:,} total")
+    # Compress the plain XML to save space; subsequent runs will find the .gz cache
+    if os.path.isfile(blast_tmp):
+        with open(blast_tmp, "rb") as _f_in, gzip.open(blast_tmp_gz, "wb") as _f_out:
+            shutil.copyfileobj(_f_in, _f_out)
+        os.remove(blast_tmp)
 
 
 def number_present(s):
@@ -1590,11 +1598,17 @@ def main(args):
 
     # interproscan
     IPRCombined = os.path.join(outputdir, "annotate_misc", "iprscan.xml")
+    IPRCombined_gz = IPRCombined + ".gz"
     IPR_terms = os.path.join(outputdir, "annotate_misc", "annotations.iprscan.txt")
-    if args.iprscan and not os.path.samefile(args.iprscan, IPRCombined):
-        if os.path.isfile(IPRCombined):
-            os.remove(IPRCombined)
-        shutil.copyfile(args.iprscan, IPRCombined)
+    if args.iprscan:
+        if args.iprscan.endswith(".gz"):
+            IPRCombined = args.iprscan
+        elif not (os.path.isfile(IPRCombined) and os.path.samefile(args.iprscan, IPRCombined)):
+            if os.path.isfile(IPRCombined):
+                os.remove(IPRCombined)
+            shutil.copyfile(args.iprscan, IPRCombined)
+    elif not os.path.isfile(IPRCombined) and os.path.isfile(IPRCombined_gz):
+        IPRCombined = IPRCombined_gz
     if not lib.checkannotations(IPRCombined):
         lib.log.error(
             "InterProScan error, %s is empty, or no XML file passed via --iprscan. Functional annotation will be lacking."
@@ -1608,13 +1622,22 @@ def main(args):
             lib.log.info("Parsing InterProScan5 XML file")
             cmd = [sys.executable, IPR2ANNOTATE, IPRCombined, IPR_terms]
             lib.runSubprocess(cmd, ".", lib.log)
+        # Compress the plain XML after parsing to save space
+        if not IPRCombined.endswith(".gz") and os.path.isfile(IPRCombined):
+            with open(IPRCombined, "rb") as _f_in, gzip.open(IPRCombined_gz, "wb") as _f_out:
+                shutil.copyfileobj(_f_in, _f_out)
+            os.remove(IPRCombined)
 
     # check if antiSMASH data is given, if so parse and reformat for annotations and cluster textual output
     antismash_input = os.path.join(outputdir, "annotate_misc", "antiSMASH.results.gbk")
-    if args.antismash and not os.path.samefile(args.antismash, antismash_input):
-        if os.path.isfile(antismash_input):
-            os.remove(antismash_input)
-        shutil.copyfile(args.antismash, antismash_input)
+    if args.antismash:
+        if args.antismash.endswith(".gz"):
+            # ParseAntiSmash (via lib._open_maybe_gzip) can read .gz directly
+            antismash_input = args.antismash
+        elif not (os.path.isfile(antismash_input) and os.path.samefile(args.antismash, antismash_input)):
+            if os.path.isfile(antismash_input):
+                os.remove(antismash_input)
+            shutil.copyfile(args.antismash, antismash_input)
     if lib.checkannotations(antismash_input):  # result found
         AntiSmashFolder = os.path.join(outputdir, "annotate_misc", "antismash")
         AntiSmashBed = os.path.join(AntiSmashFolder, "clusters.bed")

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -1360,7 +1360,7 @@ def main(args):
             # if not GeneName in NotInCurated:
             #    NotInCurated[GeneName] = GeneProduct
         _prod_before = GeneProduct
-        lib.log.debug("product_clean [%s] raw: %r", k, GeneProduct)
+        # lib.log.debug("product_clean [%s] raw: %r", k, GeneProduct)
         for _pat, _repl in product_substitutions:
             _new = _pat.sub(_repl, GeneProduct)
             if _new != GeneProduct:
@@ -1370,7 +1370,7 @@ def main(args):
                 )
                 GeneProduct = _new
         if GeneProduct != _prod_before:
-            lib.log.debug("product_clean [%s] after subs: %r", k, GeneProduct)
+            lib.log.debug("product_clean [%s] -> [%s] after subs: %r", _prod_before, k, GeneProduct)
         # if gene name in product, convert to lowercase
         if GeneName in GeneProduct:
             _before = GeneProduct
@@ -1385,7 +1385,7 @@ def main(args):
             if (
                 "By similarity" in GeneProduct
                 or "Required for" in GeneProduct
-                or "nvolved in" in GeneProduct
+                or "Involved in" in GeneProduct
                 or "protein " + GeneName == GeneProduct
                 or "nherit from" in GeneProduct
                 or len(GeneProduct) > 100
@@ -1410,7 +1410,7 @@ def main(args):
                 "product_clean [%s] unmatched-paren strip %r => %r", k, _before, GeneProduct
             )
         GeneProduct = GeneProduct.replace(" ,", ",")
-        lib.log.debug("product_clean [%s] final: %r", k, GeneProduct)
+        # lib.log.debug("product_clean [%s] final: %r", k, GeneProduct)
         # populate dictionary of NotInCurated
         if GeneName in thenots:
             if GeneName not in NotInCurated:

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -221,6 +221,13 @@ def item2index(inputList, item):
     return item_index
 
 
+def safe_samefile(path1, path2):
+    try:
+        return os.path.samefile(path1, path2)
+    except OSError:
+        return False
+
+
 def getEggNogHeaders(input):
     """
     function to get the headers from eggnog mapper annotations
@@ -1114,7 +1121,7 @@ def main(args):
     )
     egg_unique_id = str(uuid.uuid4())[-8:]
     scratch_dir = os.path.join(args.tmpdir, "emapper-{}".format(egg_unique_id))
-    if args.eggnog and not os.path.samefile(args.eggnog, eggnog_result):
+    if args.eggnog and not safe_samefile(args.eggnog, eggnog_result):
         if os.path.isfile(eggnog_result):
             os.remove(eggnog_result)
         shutil.copyfile(args.eggnog, eggnog_result)
@@ -1513,7 +1520,7 @@ def main(args):
     # run Phobius if local is installed, otherwise you will have to use funannotate remote
     phobius_out = os.path.join(outputdir, "annotate_misc", "phobius.results.txt")
     phobiusLog = os.path.join(outputdir, "logfiles", "phobius.log")
-    if args.phobius and not os.path.samefile(args.phobius, phobius_out):
+    if args.phobius and not safe_samefile(args.phobius, phobius_out):
         if os.path.isfile(phobius_out):
             os.remove(phobius_out)
         shutil.copyfile(args.phobius, phobius_out)
@@ -1547,7 +1554,7 @@ def main(args):
     membrane_out = os.path.join(
         outputdir, "annotate_misc", "annotations.transmembrane.txt"
     )
-    if args.signalp and not os.path.samefile(args.signalp, signalp_out):
+    if args.signalp and not safe_samefile(args.signalp, signalp_out):
         shutil.copyfile(args.signalp, signalp_out)
     if lib.which("signalp") or lib.which("signalp6") or lib.checkannotations(signalp_out):
         if not lib.checkannotations(signalp_out):

--- a/funannotate/annotate.py
+++ b/funannotate/annotate.py
@@ -125,13 +125,13 @@ def SwissProtBlast(input, cpus, evalue, tmpdir, GeneDict, diamond=True):
             input,
         ]
     blast_tmp_gz = blast_tmp + ".gz"
-    if not lib.checkannotations(blast_tmp) and not os.path.isfile(blast_tmp_gz):
+    use_gzip_cache = lib.checkannotations(blast_tmp_gz)
+    if not lib.checkannotations(blast_tmp) and not use_gzip_cache:
         lib.runSubprocess(cmd, ".", lib.log, only_failed=True)
-    # parse results — support a gzip-compressed cached copy
-    counter = 0
-    total = 0
-    _opener = gzip.open(blast_tmp_gz, "rt") if os.path.isfile(blast_tmp_gz) else open(blast_tmp, "r")
-    with _opener as results:
+
+    def _parse_swissprot_results(results):
+        counter = 0
+        total = 0
         for qresult in SearchIO.parse(results, "blast-xml"):
             hits = qresult.hits
             qlen = qresult.seq_len
@@ -185,6 +185,26 @@ def SwissProtBlast(input, cpus, evalue, tmpdir, GeneDict, diamond=True):
                                 "source": "UniProtKB",
                             }
                         )
+        return counter, total
+
+    # parse results — support a gzip-compressed cached copy
+    try:
+        if use_gzip_cache:
+            with gzip.open(blast_tmp_gz, "rt") as results:
+                counter, total = _parse_swissprot_results(results)
+        else:
+            with open(blast_tmp, "r") as results:
+                counter, total = _parse_swissprot_results(results)
+    except Exception:
+        if not use_gzip_cache:
+            raise
+        lib.log.debug("Cached UniProt XML %s is unreadable, regenerating", blast_tmp_gz)
+        if os.path.isfile(blast_tmp_gz):
+            os.remove(blast_tmp_gz)
+        if not lib.checkannotations(blast_tmp):
+            lib.runSubprocess(cmd, ".", lib.log, only_failed=True)
+        with open(blast_tmp, "r") as results:
+            counter, total = _parse_swissprot_results(results)
     lib.log.info(f"{counter:,} valid gene/product annotations from {total:,} total")
     # Compress the plain XML to save space; subsequent runs will find the .gz cache
     if os.path.isfile(blast_tmp):

--- a/funannotate/aux_scripts/iprscan2annotations.py
+++ b/funannotate/aux_scripts/iprscan2annotations.py
@@ -4,6 +4,7 @@
 # it will parse an interproscan5 xml file and generate
 # genome annotation file for GO terms and IPR terms
 
+import gzip
 import sys
 import os
 import xml.etree.cElementTree as etree
@@ -40,8 +41,9 @@ def main():
         goDict[item.id] = {"name": item.name, "namespace": namespace}
         for nm in item.alt_ids:  # also index by alt_id since that may be reported
             goDict[nm] = {"name": item.name, "namespace": namespace}
+    _opener = gzip.open(sys.argv[1], "rt") if sys.argv[1].endswith(".gz") else open(sys.argv[1])
     with open(sys.argv[2], "w") as output:
-        with open(sys.argv[1]) as xml_file:
+        with _opener as xml_file:
             tree = etree.iterparse(xml_file)
             for _, elem in tree:
                 if "}" in elem.tag:

--- a/funannotate/aux_scripts/runIPRscan.py
+++ b/funannotate/aux_scripts/runIPRscan.py
@@ -417,8 +417,7 @@ elif options.email and not options.jobid:
 
     # Submit the job
     jobid = serviceRun(options.email, options.title, params)
-    if options.asyncjob:
-       # Async mode
+    if options.asyncjob:  # Async mode
         print(jobid)
     else:  # Sync mode
         print(jobid, file=sys.stderr)

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -9020,7 +9020,10 @@ def ParseErrorReport(input, Errsummary, val, Discrep, output, keep_stops):
 
 def _open_maybe_gzip(path, mode="r"):
     if path.endswith(".gz"):
-        return gzip.open(path, mode + "t")
+        gzip_mode = mode
+        if "b" not in gzip_mode and "t" not in gzip_mode:
+            gzip_mode += "t"
+        return gzip.open(path, gzip_mode)
     return open(path, mode)
 
 

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -9018,10 +9018,16 @@ def ParseErrorReport(input, Errsummary, val, Discrep, output, keep_stops):
                         out.write(line)
 
 
+def _open_maybe_gzip(path, mode="r"):
+    if path.endswith(".gz"):
+        return gzip.open(path, mode + "t")
+    return open(path, mode)
+
+
 def antismash_version(input):
     # choose v4, v5 or v6 parser
     version = 4
-    with open(input, "r") as infile:
+    with _open_maybe_gzip(input) as infile:
         for rec in SeqIO.parse(infile, "genbank"):
             if "structured_comment" in rec.annotations:
                 if "antiSMASH-Data" in rec.annotations["structured_comment"]:
@@ -9049,7 +9055,7 @@ def ParseAntiSmash(input, tmpdir, output, annotations):
     cogCount = 0
     # parse antismash genbank to get clusters in bed format and slice the record for each cluster prediction
     with open(output, "w") as antibed:
-        with open(input, "r") as input:
+        with _open_maybe_gzip(input) as input:
             SeqRecords = SeqIO.parse(input, "genbank")
             for rec_num, record in enumerate(SeqRecords):
                 for f in record.features:

--- a/tests/test_annotate_gzip_cache.py
+++ b/tests/test_annotate_gzip_cache.py
@@ -1,0 +1,85 @@
+import importlib
+import importlib.util
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+
+if not hasattr(importlib.util, "module_for_loader"):
+    def module_for_loader(func):
+        return func
+
+
+    importlib.util.module_for_loader = module_for_loader
+
+
+annotate = importlib.import_module("funannotate.annotate")
+annotate.FUNDB = "/tmp/funannotate-db"
+
+
+class _FakeHSP(object):
+    aln_span = 100
+    ident_num = 95
+
+
+class _FakeHit(object):
+    hsps = [_FakeHSP()]
+    description = "Valid protein OS=Example species GN=ABC1"
+    id = "sp|P12345|ABC1"
+
+
+class _FakeResult(object):
+    hits = [_FakeHit()]
+    seq_len = 100
+    id = "gene1"
+
+
+class SwissProtBlastGzipCacheTests(unittest.TestCase):
+    def test_zero_byte_gzip_cache_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gzip_cache = os.path.join(tmpdir, "uniprot.xml.gz")
+            open(gzip_cache, "w").close()
+
+            def _write_plain_xml(*args, **kwargs):
+                with open(os.path.join(tmpdir, "uniprot.xml"), "w") as handle:
+                    handle.write("<xml />\n")
+
+            with mock.patch.object(annotate.lib, "log", mock.Mock(), create=True), \
+                mock.patch.object(annotate.lib, "runSubprocess", side_effect=_write_plain_xml) as run_subprocess, \
+                mock.patch.object(annotate.SearchIO, "parse", return_value=[]):
+                annotate.SwissProtBlast("proteins.fa", 1, 1e-5, tmpdir, {}, diamond=True)
+
+            self.assertEqual(run_subprocess.call_count, 1)
+
+    def test_invalid_gzip_cache_is_regenerated(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gzip_cache = os.path.join(tmpdir, "uniprot.xml.gz")
+            with open(gzip_cache, "wb") as handle:
+                handle.write(b"not-a-valid-gzip")
+
+            def _write_plain_xml(*args, **kwargs):
+                with open(os.path.join(tmpdir, "uniprot.xml"), "w") as handle:
+                    handle.write("<xml />\n")
+
+            def _parse_results(handle, fmt):
+                self.assertEqual(fmt, "blast-xml")
+                if handle.name.endswith(".gz"):
+                    raise OSError("truncated gzip cache")
+                return [_FakeResult()]
+
+            gene_dict = {}
+            with mock.patch.object(annotate.lib, "log", mock.Mock(), create=True), \
+                mock.patch.object(annotate.lib, "runSubprocess", side_effect=_write_plain_xml) as run_subprocess, \
+                mock.patch.object(annotate.SearchIO, "parse", side_effect=_parse_results):
+                annotate.SwissProtBlast("proteins.fa", 1, 1e-5, tmpdir, gene_dict, diamond=True)
+
+            self.assertEqual(run_subprocess.call_count, 1)
+            self.assertIn("gene1", gene_dict)
+            self.assertEqual(gene_dict["gene1"][0]["name"], "ABC1")
+            self.assertTrue(os.path.isfile(gzip_cache))
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, "uniprot.xml")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If we store uniprot.xml and iprscan.xml as gzip for space savings and can parse these.