### PR TITLE
Auto skip genemark

### DIFF
--- a/funannotate/aux_scripts/tbl2asn_parallel.py
+++ b/funannotate/aux_scripts/tbl2asn_parallel.py
@@ -84,7 +84,11 @@ def tbl2asn_safe_run(cmd, dir, dialect='tbl2asn'):
 
 def tbl2asn_runner(cmd, dir, dialect='tbl2asn'):
     indir_flag = '-indir' if dialect == 'table2asn' else '-p'
-    cmd = cmd + ['-Z', os.path.join(dir, 'discrepency.report.txt'), indir_flag, dir]
+    if dialect == 'table2asn':
+        # table2asn: -Z is a boolean flag; discrepancy written as <input>.dr
+        cmd = cmd + ['-Z', indir_flag, dir]
+    else:
+        cmd = cmd + ['-Z', os.path.join(dir, 'discrepency.report.txt'), indir_flag, dir]
     print("DEBUG tbl2asn_runner cmd: %s" % " ".join(cmd), flush=True)
     result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.stdout:
@@ -168,7 +172,7 @@ def runtbl2asn_parallel(folder, template, discrepency, organism, isolate, strain
                             elif f.endswith('.sqn'):
                                 shutil.copyfile(os.path.join(
                                     dirName, f), os.path.join(folder, f))
-                            elif f == 'discrepency.report.txt':
+                            elif f == 'discrepency.report.txt' or f.endswith('.dr'):
                                 with open(os.path.join(dirName, f)) as infile:
                                     discrep.write(infile.read())
 

--- a/funannotate/library.py
+++ b/funannotate/library.py
@@ -8544,7 +8544,10 @@ def build_tbl2asn_cmd(
         "-T",
     ]
     if discrepancy:
-        cmd += ["-Z", discrepancy]
+        if dialect == "table2asn":
+            cmd += ["-Z"]  # table2asn: boolean flag only; writes <input>.dr alongside output
+        else:
+            cmd += ["-Z", discrepancy]
     # tbl2asn-only flags: cleanup (-c) and assembly-format (-a) have no
     # equivalent in table2asn and trigger errors there
     if dialect == "tbl2asn":

--- a/funannotate/predict.py
+++ b/funannotate/predict.py
@@ -1687,6 +1687,7 @@ def main(args):
                         % (len(longest10), ", ".join([str(x) for x in longest10]))
                     )
                     StartWeights["genemark"] = 0
+                    trainingData["genemark"] = [{}]
                 else:
                     lib.log.error(
                         "GeneMark-ES may fail because this assembly appears to be highly fragmented:\n\

--- a/funannotate/predict.py
+++ b/funannotate/predict.py
@@ -244,6 +244,12 @@ def main(args):
     parser.add_argument("--trnascan", help="Pre-computed tRNAScan results")
     parser.add_argument("--tmpdir", default="/tmp", help="volume to write tmp files")
     parser.add_argument(
+        "--auto-skip-genemark",
+        action="store_true",
+        default=False,
+        help="If assembly appears highly fragmented (longest scaffold <50 kb), automatically set GeneMark weight to 0 and skip it instead of attempting to run",
+    )
+    parser.add_argument(
         "--table",
         default=1,
         type=int,
@@ -1674,16 +1680,27 @@ def main(args):
             # count contigs
             num_contigs = lib.countfasta(MaskGenome)
             if longest10[0] < 50000:
-                lib.log.error(
-                    "GeneMark-ES may fail because this assembly appears to be highly fragmented:\n\
+                if args.auto_skip_genemark:
+                    lib.log.warning(
+                        "Assembly appears highly fragmented (longest %s scaffolds: %s). "
+                        "--auto-skip-genemark set: resetting GeneMark weight to 0 and skipping."
+                        % (len(longest10), ", ".join([str(x) for x in longest10]))
+                    )
+                    StartWeights["genemark"] = 0
+                else:
+                    lib.log.error(
+                        "GeneMark-ES may fail because this assembly appears to be highly fragmented:\n\
 -------------------------------------------------------\n\
 The longest %s scaffolds are: %s.\n\
 If you can run GeneMark outside funannotate you can add with --genemark_gtf option.\n\
+Use --auto-skip-genemark to automatically skip GeneMark on fragmented assemblies.\n\
 -------------------------------------------------------"
-                    % (len(longest10), ", ".join([str(x) for x in longest10]))
-                )
+                        % (len(longest10), ", ".join([str(x) for x in longest10]))
+                    )
             # now run GeneMark, check for number of contigs and ini
-            if num_contigs < 2 and not args.genemark_mod:
+            if StartWeights["genemark"] == 0:
+                pass  # weight was zeroed (e.g. by --auto-skip-genemark); skip all GeneMark execution
+            elif num_contigs < 2 and not args.genemark_mod:
                 lib.log.error(
                     "GeneMark-ES cannot run with only a single contig, you must provide --ini_mod file to run GeneMark"
                 )

--- a/tests/test_tbl2asn.py
+++ b/tests/test_tbl2asn.py
@@ -103,6 +103,20 @@ class BuildTbl2asnCmdDialectTests(unittest.TestCase):
         cmd = self._cmd("tbl2asn", discrepancy=None)
         self.assertNotIn("-Z", cmd)
 
+    def test_table2asn_discrepancy_flag_only_no_filepath(self):
+        # table2asn -Z is a boolean flag; passing a filepath causes it to fail
+        cmd = self._cmd("table2asn", discrepancy="/tmp/discrep.txt")
+        self.assertIn("-Z", cmd)
+        idx = cmd.index("-Z")
+        # next token must not be the filepath (it should be another flag or end of list)
+        if idx + 1 < len(cmd):
+            self.assertFalse(cmd[idx + 1].endswith(".txt"),
+                             "table2asn -Z must not be followed by a file path")
+
+    def test_table2asn_discrepancy_absent_when_none(self):
+        cmd = self._cmd("table2asn", discrepancy=None)
+        self.assertNotIn("-Z", cmd)
+
     # --- extra parameters ---
 
     def test_extra_parameters_appended(self):


### PR DESCRIPTION
Add a flag to auto-skip using genemark if it fails because the genome is too fragmented. This is helpful for large workflow runs where we just want to get a prediction, this flag is off by default but will help speed up processing without a re-run if this issue is detected.