### PR TITLE
Fix two deadlocks in the BUSCO step that hang `funannotate predict`

### DIFF
--- a/funannotate/aux_scripts/funannotate-BUSCO2.py
+++ b/funannotate/aux_scripts/funannotate-BUSCO2.py
@@ -350,7 +350,24 @@ class Analysis(object, metaclass=ABCMeta):
                 os.killpg(os.getpgid(process.pid), signal.SIGKILL)
             except ProcessLookupError:
                 pass
-            process.communicate()
+            # Reap the killed process, but NEVER block forever here: if Augustus left a
+            # grandchild that escaped the process group and still holds the stdout/stderr
+            # pipe open, a bare communicate() waits for EOF that never comes -> the worker
+            # thread hangs -> the main loop's t.join() deadlocks the whole BUSCO step.
+            # Bounding this call (and closing the pipes on a second timeout) prevents that.
+            try:
+                process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                for _stream in (process.stdout, process.stderr):
+                    try:
+                        if _stream is not None:
+                            _stream.close()
+                    except Exception:
+                        pass
+                try:
+                    process.wait(timeout=5)
+                except Exception:
+                    pass
             _logger.warning(
                 '%s timed out after %s seconds, skipping this gene model' % (name, timeout)
             )
@@ -896,6 +913,8 @@ class Analysis(object, metaclass=ABCMeta):
         self._augustus_timeout_count = 0
         self._augustus_durations = []
         self._augustus_stats_lock = threading.Lock()
+        # Guards the shared self.slate progress list against concurrent read/pop by workers.
+        self._slate_lock = threading.Lock()
         self._tarzip = params['tarzip']
         self._dataset_creation_date = params['dataset_creation_date']
         self._dataset_nb_species = params['dataset_nb_species']
@@ -1137,10 +1156,17 @@ class Analysis(object, metaclass=ABCMeta):
             self._work_queue.put(word)
         self._queue_lock.release()
 
-        # Wait for all jobs to finish (i.e. queue being empty)
+        # Wait for all jobs to finish (i.e. queue being empty). Guard against a deadlock:
+        # if every worker thread dies (e.g. an unhandled per-task error such as the
+        # self.slate race below), the queue never drains and this loop would spin forever.
+        # Break out instead of hanging the whole BUSCO/predict step.
         while not self._work_queue.empty():
+            if not any(t.is_alive() for t in threads):
+                _logger.warning(
+                    'All %d worker thread(s) exited with %d task(s) still queued; '
+                    'continuing without them.' % (len(threads), self._work_queue.qsize()))
+                break
             time.sleep(0.01)
-            pass
         # Send exit signal
         self._exit_flag = 1
 
@@ -2076,20 +2102,28 @@ class Analysis(object, metaclass=ABCMeta):
             if not self._work_queue.empty():
                 data = self._work_queue.get()
                 self._queue_lock.release()
-                check = len([name for name in os.listdir('%saugustus_output/predicted_genes' % self.mainout) if
-                             os.path.isfile(os.path.join('%saugustus_output/predicted_genes' % self.mainout, name))])
-                state = 100 * check / self._total
-                if state > self.slate[-1]:
-                    _logger.info('%s =>\t%s%% of predictions performed (%i/%i candidate regions)'
-                                 % (time.strftime("%m/%d/%Y %H:%M:%S"), self.slate.pop(), check, self._total))
-                _t0 = time.time()
-                completed = Analysis.p_open([data], 'augustus', shell=True, timeout=self._augustus_timeout)
-                elapsed = time.time() - _t0
-                with self._augustus_stats_lock:
-                    self._augustus_durations.append(elapsed)
-                    if not completed:
-                        self._augustus_timeout_count += 1
-                _logger.debug('augustus job elapsed %.1fs%s' % (elapsed, ' [TIMED OUT]' if not completed else ''))
+                # A per-task error must never kill the worker thread: a dead worker leaves
+                # tasks in the queue and deadlocks _run_threads' wait loop.
+                try:
+                    check = len([name for name in os.listdir('%saugustus_output/predicted_genes' % self.mainout) if
+                                 os.path.isfile(os.path.join('%saugustus_output/predicted_genes' % self.mainout, name))])
+                    state = 100 * check / self._total if self._total else 0
+                    # self.slate is shared across workers: guard the read+pop so an empty
+                    # slate (race) cannot raise IndexError and kill the thread.
+                    with self._slate_lock:
+                        if self.slate and state > self.slate[-1]:
+                            _logger.info('%s =>\t%s%% of predictions performed (%i/%i candidate regions)'
+                                         % (time.strftime("%m/%d/%Y %H:%M:%S"), self.slate.pop(), check, self._total))
+                    _t0 = time.time()
+                    completed = Analysis.p_open([data], 'augustus', shell=True, timeout=self._augustus_timeout)
+                    elapsed = time.time() - _t0
+                    with self._augustus_stats_lock:
+                        self._augustus_durations.append(elapsed)
+                        if not completed:
+                            self._augustus_timeout_count += 1
+                    _logger.debug('augustus job elapsed %.1fs%s' % (elapsed, ' [TIMED OUT]' if not completed else ''))
+                except Exception as e:
+                    _logger.warning('augustus task error (skipped): %s' % e)
             else:
                 self._queue_lock.release()
 
@@ -2102,13 +2136,18 @@ class Analysis(object, metaclass=ABCMeta):
             if not self._work_queue.empty():
                 data = self._work_queue.get()
                 self._queue_lock.release()
-                check = len([name for name in os.listdir('%shmmer_output' % self.mainout) if
-                             os.path.isfile(os.path.join('%shmmer_output' % self.mainout, name))])
-                state = 100 * check / self._total
-                if state > self.slate[-1]:
-                    _logger.info('%s =>\t%s%% of predictions performed (%i/%i candidate proteins)'
-                                 % (time.strftime("%m/%d/%Y %H:%M:%S"), self.slate.pop(), check, self._total))
-                Analysis.p_open(data, 'hmmersearch', shell=False)
+                # A per-task error must never kill the worker thread (see _process_augustus_tasks).
+                try:
+                    check = len([name for name in os.listdir('%shmmer_output' % self.mainout) if
+                                 os.path.isfile(os.path.join('%shmmer_output' % self.mainout, name))])
+                    state = 100 * check / self._total if self._total else 0
+                    with self._slate_lock:
+                        if self.slate and state > self.slate[-1]:
+                            _logger.info('%s =>\t%s%% of predictions performed (%i/%i candidate proteins)'
+                                         % (time.strftime("%m/%d/%Y %H:%M:%S"), self.slate.pop(), check, self._total))
+                    Analysis.p_open(data, 'hmmersearch', shell=False)
+                except Exception as e:
+                    _logger.warning('hmmersearch task error (skipped): %s' % e)
             else:
                 self._queue_lock.release()
 


### PR DESCRIPTION
# Fix two deadlocks in the BUSCO step that hang `funannotate predict`

## Summary

`funannotate predict` can hang **indefinitely** in the BUSCO ab-initio training step
(`funannotate/aux_scripts/funannotate-BUSCO2.py`), with 0% CPU and no progress. We hit this
reproducibly on every run of a ~34 Mb fungal genome (*Paracoccidioides lutzii*) inside the
official `nextgenusfs/funannotate` Docker image. This PR fixes **two independent deadlocks** in
that file. With both fixes, `predict` completes the BUSCO step, trains AUGUSTUS, and produces the
annotation as expected.

We located the second one with a `py-spy dump` of the hung process (stack at the bottom).

---

## Bug #1 — `Analysis.p_open`: unbounded `communicate()` after killing a timed-out AUGUSTUS

### Cause
When an AUGUSTUS job exceeds `--augustus_timeout`, `p_open` kills its process group with
`os.killpg(SIGKILL)` and then calls a **bare `process.communicate()` with no timeout**:

```python
except subprocess.TimeoutExpired:
    try:
        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
    except ProcessLookupError:
        pass
    process.communicate()          # <-- can block forever
```

`communicate()` reads stdout/stderr until EOF, i.e. until **every** copy of the pipe write-end is
closed. If the killed AUGUSTUS left a grandchild that escaped the process group (e.g. via
`setsid`) and still holds the pipe open, EOF never arrives and this call blocks forever. The
worker thread that called `p_open` never returns, so the `t.join()` in `_run_threads` hangs the
whole BUSCO step.

### Fix
Bound the post-kill reap and, if it still does not return, close the pipes and stop waiting. The
problematic gene model is skipped, which is the intent of the timeout anyway:

```python
try:
    process.communicate(timeout=30)
except subprocess.TimeoutExpired:
    for _stream in (process.stdout, process.stderr):
        try:
            if _stream is not None:
                _stream.close()
        except Exception:
            pass
    try:
        process.wait(timeout=5)
    except Exception:
        pass
```

---

## Bug #2 — race on the shared `self.slate` progress list crashes workers → `_run_threads` spins forever

### Cause
The worker task processors (`_process_augustus_tasks`, `_process_hmmer_tasks`) update a shared
progress-milestone list `self.slate` **without any lock**:

```python
if state > self.slate[-1]:
    _logger.info('... %s%% ...' % (..., self.slate.pop(), ...))
```

`self.slate` is shared by all worker threads. This is a data race: when `slate` empties, two
threads can both pass `state > self.slate[-1]` and then both call `self.slate.pop()`, or one reads
`self.slate[-1]` on an already-empty list. Either way it raises **`IndexError`**, which is
unhandled and **kills the worker thread**. Once enough workers die, the work queue is never
drained, and the main thread spins forever in `_run_threads`:

```python
while not self._work_queue.empty():   # never becomes empty -> infinite loop
    time.sleep(0.01)
```

This is timing-dependent, so it is intermittent (it sometimes completes). When it triggers,
`py-spy` shows a single live thread busy-looping here (`time.sleep` shows up as `do_select`):

```
Thread (active): "MainThread"
    _run_threads (funannotate-BUSCO2.py:1159)
    _hmmer       (funannotate-BUSCO2.py:2570)
    run_analysis (funannotate-BUSCO2.py:2256)
    main         (funannotate-BUSCO2.py:3387)
```

### Fix (three parts)
1. **Synchronize `self.slate`** with a dedicated `self._slate_lock`, and guard against an empty
   list so it can no longer raise:
   ```python
   with self._slate_lock:
       if self.slate and state > self.slate[-1]:
           _logger.info(... self.slate.pop() ...)
   ```
2. **Make workers exception-proof**: wrap each worker's per-task body in `try/except` so any
   per-task error is logged and skipped instead of killing the thread.
3. **Backstop in `_run_threads`**: break the wait loop if no worker thread is alive anymore,
   instead of spinning forever:
   ```python
   while not self._work_queue.empty():
       if not any(t.is_alive() for t in threads):
           _logger.warning('All worker thread(s) exited with tasks still queued; continuing.')
           break
       time.sleep(0.01)
   ```

---

## Validation

- **Bug #1**: a minimal reproduction (a grandchild that `setsid`-escapes the group and holds the
  pipe) — the original code hangs, the patched code returns.
- **Bug #2**: deterministic unit checks for both fix components — (A) `self.slate.pop()` on an
  empty list raises `IndexError` unguarded but not when guarded; (B) the `_run_threads` wait loop
  spins forever with dead workers but terminates with the backstop.
- **End-to-end**: `funannotate predict` on a *Paracoccidioides lutzii* genome that previously hung
  twice now passes BUSCO, trains AUGUSTUS, and produces the proteome (7,630 proteins), including
  the expected PRP8 intein.

## Notes
- All changes are confined to `funannotate/aux_scripts/funannotate-BUSCO2.py`.
- No behavior change on the happy path; the fixes only affect the timeout/error/edge cases that
  currently deadlock.
