### PR TITLE
Fix setup crash when a database's metadata record is missing (#1171)

### DIFF
--- a/funannotate/setupDB.py
+++ b/funannotate/setupDB.py
@@ -138,7 +138,7 @@ def meropsDB(info, force=False, args={}):
     if os.path.isfile(fasta) and args.update and not force:
         if check4newDB('merops', info):
             force = True
-    if not os.path.isfile(fasta) or force:
+    if not os.path.isfile(fasta) or force or 'merops' not in info:
         lib.log.info('Downloading Merops database')
         for x in [fasta, filtered, database]:
             if os.path.isfile(x):
@@ -181,7 +181,7 @@ def uniprotDB(info, force=False, args={}):
     if os.path.isfile(fasta) and args.update and not force:
         if check4newDB('uniprot-release', info):
             force = True
-    if not os.path.isfile(fasta) or force:
+    if not os.path.isfile(fasta) or force or 'uniprot' not in info:
         lib.log.info('Downloading UniProtKB/SwissProt database')
         for x in [fasta, fasta+'.gz', versionfile, database]:
             if os.path.isfile(x):
@@ -226,7 +226,7 @@ def dbCANDB(info, force=False, args={}):
     if os.path.isfile(hmm) and args.update and not force:
         if check4newDB('dbCAN', info):
             force = True
-    if not os.path.isfile(hmm) or force:
+    if not os.path.isfile(hmm) or force or 'dbCAN' not in info:
         lib.log.info('Downloading dbCAN database')
         for x in [os.path.join(FUNDB, 'dbCAN.tmp'), hmm, familyinfo, versionfile]:
             if os.path.isfile(x):
@@ -274,7 +274,7 @@ def pfamDB(info, force=False, args={}):
     if os.path.isfile(hmm) and args.update and not force:
         if check4newDB('pfam-log', info):
             force = True
-    if not os.path.isfile(hmm) or force:
+    if not os.path.isfile(hmm) or force or 'pfam' not in info:
         for x in [hmm, hmm+'.gz', familyinfo, familyinfo+'.gz', versionfile, versionfile+'.gz']:
             if os.path.isfile(x):
                 os.remove(x)
@@ -321,7 +321,7 @@ def repeatDB(info, force=False, args={}):
     if os.path.isfile(fasta) and args.update and not force:
         if check4newDB('repeats', info):
             force = True
-    if not os.path.isfile(fasta) or force:
+    if not os.path.isfile(fasta) or force or 'repeats' not in info:
         lib.log.info('Downloading Repeat database')
         for x in [fasta, fasta+'.tar.gz', filtered, database]:
             if os.path.isfile(x):
@@ -358,7 +358,7 @@ def outgroupsDB(info, force=False, args={}):
     if os.path.isdir(OutGroups) and args.update and not force:
         if check4newDB('outgroups', info):
             force = True
-    if not os.path.isdir(OutGroups) or force:
+    if not os.path.isdir(OutGroups) or force or 'busco_outgroups' not in info:
         lib.log.info('Downloading pre-computed BUSCO outgroups')
         if os.path.isdir(os.path.join(FUNDB, 'outgroups')):
             shutil.rmtree(os.path.join(FUNDB, 'outgroups'))
@@ -385,7 +385,7 @@ def goDB(info, force=False, args={}):
     if os.path.isfile(goOBO) and args.update and not force:
         if check4newDB('go-obo', info):
             force = True
-    if not os.path.isfile(goOBO) or force:
+    if not os.path.isfile(goOBO) or force or 'go' not in info:
         lib.log.info('Downloading GO Ontology database')
         for x in [goOBO]:
             if os.path.isfile(x):
@@ -416,7 +416,7 @@ def mibigDB(info, force=False, args={}):
     if os.path.isfile(fasta) and args.update and not force:
         if check4newDB('mibig', info):
             force = True
-    if not os.path.isfile(fasta) or force:
+    if not os.path.isfile(fasta) or force or 'mibig' not in info:
         lib.log.info('Downloading MiBIG Secondary Metabolism database')
         for x in [fasta, database]:
             if os.path.isfile(x):
@@ -444,7 +444,7 @@ def interproDB(info, force=False, args={}):
     if os.path.isfile(iprXML) and args.update and not force:
         if check4newDB('interpro', info):
             force = True
-    if not os.path.isfile(iprXML) or force:
+    if not os.path.isfile(iprXML) or force or 'interpro' not in info:
         lib.log.info('Downloading InterProScan Mapping file')
         for x in [iprXML, iprTSV, iprXML+'.gz']:
             if os.path.isfile(x):
@@ -485,7 +485,7 @@ def curatedDB(info, force=False, args={}):
     if os.path.isfile(curatedFile) and args.update and not force:
         if check4newDB('gene2product', info):
             force = True
-    if not os.path.isfile(curatedFile) or force:
+    if not os.path.isfile(curatedFile) or force or 'gene2product' not in info:
         lib.log.info('Downloaded curated gene names and product descriptions')
         for x in [curatedFile]:
             if os.path.isfile(x):

--- a/tests/test_setupdb_missing_info.py
+++ b/tests/test_setupdb_missing_info.py
@@ -1,0 +1,74 @@
+"""Regression test for GitHub issue #1171.
+
+`funannotate setup` crashed with `TypeError: cannot unpack non-iterable NoneType
+object` when a database data file was present on disk but its metadata was missing
+from the in-memory `info` dict (e.g. an interrupted earlier setup left the data
+file behind but `funannotate.txt` was absent or incomplete). The per-database
+helpers only populated `info[<db>]` inside the download branch, then unconditionally
+unpacked `info.get(<db>)` -- which is `None` when that branch is skipped.
+
+The fix makes the download branch also trigger when the metadata entry is missing,
+so the entry is always (re)populated before it is unpacked.
+"""
+import importlib
+import os
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+
+setupDB = importlib.import_module("funannotate.setupDB")
+
+
+class MeropsMissingInfoTests(unittest.TestCase):
+    def _run_with_existing_fasta_but_empty_info(self, info):
+        """Simulate: data file already on disk, but `info` has no 'merops' entry."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fasta = os.path.join(tmp, "meropsscan.lib")
+            with open(fasta, "w") as fh:                # pre-existing data file
+                fh.write(">MER0001 #A01.001\nMKQ\n")
+
+            def fake_download(url, name, wget=False):
+                with open(name, "w") as fh:
+                    fh.write(">MER0001 #A01.001\nMKQ\n")
+
+            args = types.SimpleNamespace(update=False, wget=False, force=False)
+            with mock.patch.object(setupDB, "FUNDB", tmp, create=True), \
+                    mock.patch.object(setupDB, "DBURL", {"merops": "http://example/merops"}, create=True), \
+                    mock.patch.object(setupDB.lib, "log", mock.MagicMock(), create=True), \
+                    mock.patch.object(setupDB, "download", fake_download), \
+                    mock.patch.object(setupDB, "calcmd5", lambda *_a, **_k: "deadbeef"), \
+                    mock.patch.object(setupDB.lib, "runSubprocess", lambda *_a, **_k: None), \
+                    mock.patch.object(setupDB.lib, "countfasta", lambda *_a, **_k: 1):
+                setupDB.meropsDB(info, force=False, args=args)
+            return info
+
+    def test_missing_metadata_does_not_crash_and_is_repopulated(self):
+        info = {}                                       # no 'merops' key -> used to crash
+        result = self._run_with_existing_fasta_but_empty_info(info)
+        self.assertIn("merops", result)
+        self.assertEqual(len(result["merops"]), 6)      # full metadata tuple recovered
+
+    def test_present_metadata_is_left_untouched(self):
+        # When metadata is already known and the data file exists, no re-download
+        # should happen and the existing record must be preserved.
+        existing = ("diamond", "/x/merops.dmnd", "12.5", "2023-01-19", 42, "cafef00d")
+        info = {"merops": existing}
+        with tempfile.TemporaryDirectory() as tmp:
+            fasta = os.path.join(tmp, "meropsscan.lib")
+            open(fasta, "w").close()
+            args = types.SimpleNamespace(update=False, wget=False, force=False)
+
+            def fail_download(*_a, **_k):               # must NOT be called
+                raise AssertionError("re-download triggered for an up-to-date DB")
+
+            with mock.patch.object(setupDB, "FUNDB", tmp, create=True), \
+                    mock.patch.object(setupDB.lib, "log", mock.MagicMock(), create=True), \
+                    mock.patch.object(setupDB, "download", fail_download):
+                setupDB.meropsDB(info, force=False, args=args)
+        self.assertEqual(info["merops"], existing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1171

### Problem
`funannotate setup` aborts with:

```
File ".../funannotate/setupDB.py", line 175, in meropsDB
    type, name, version, date, records, checksum = info.get('merops')
TypeError: cannot unpack non-iterable NoneType object
```

Each per-database helper in `setupDB.py` only populates `info[<db>]` **inside** the download branch (`if not os.path.isfile(<file>) or force:`), and then unconditionally unpacks `info.get(<db>)`. When a data file is already present on disk but its metadata is missing from `info` — e.g. an earlier setup was interrupted, or `funannotate.txt` is absent/incomplete — the download branch is skipped, so `info.get(<db>)` returns `None` and the unpack raises `TypeError`.

### Fix
Trigger the download/registration branch **also** when the metadata entry is missing, so the record is always (re)populated before it is unpacked:

```python
if not os.path.isfile(fasta) or force or 'merops' not in info:
```

Applied consistently to all ten database helpers (merops, uniprot, dbCAN, pfam, repeats, busco_outgroups, go, mibig, interpro, gene2product). Behaviour only changes in the broken scenario; a normal fresh or up-to-date setup is unaffected (the data file is absent → already downloads, or the metadata is present → no change).

### Testing
Adds `tests/test_setupdb_missing_info.py`. The new test reproduces the exact `TypeError` on the unpatched code and passes with the fix; existing tests still pass.