### PR TITLE
Keep the execute bit on bundled aux_scripts after install (#1129)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import sys
 from shutil import rmtree
 
 from setuptools import find_packages, setup, Command
+from setuptools.command.build_py import build_py as _build_py
 
 # Package meta-data.
 NAME = "funannotate"
@@ -109,6 +110,34 @@ class UploadCommand(Command):
         sys.exit()
 
 
+class BuildPyCommand(_build_py):
+    """build_py that preserves the execute bit on bundled helper scripts.
+
+    The scripts in ``funannotate/aux_scripts`` are shipped as package data and
+    several of them are launched directly via their shebang at runtime (the
+    Perl/shell helpers, phobius-multiproc.py, etc.). When funannotate is
+    installed from a wheel/sdist the copied data files do not reliably keep
+    their execute bit, leaving those scripts non-executable after install and
+    breaking the pipeline (issue #1129). Re-assert the execute bits on the
+    build output so the wheel -- and therefore the installation -- keep them.
+    """
+
+    _EXECUTABLE_DIRS = (os.path.join("funannotate", "aux_scripts"),)
+
+    def run(self):
+        super().run()
+        for reldir in self._EXECUTABLE_DIRS:
+            target = os.path.join(self.build_lib, reldir)
+            if not os.path.isdir(target):
+                continue
+            for name in os.listdir(target):
+                path = os.path.join(target, name)
+                if os.path.isfile(path):
+                    mode = os.stat(path).st_mode
+                    # mirror the read bits into execute bits (u/g/o), e.g. 0644 -> 0755
+                    os.chmod(path, mode | ((mode & 0o444) >> 2))
+
+
 # Where the magic happens:
 setup(
     name=NAME,
@@ -142,5 +171,6 @@ setup(
     ],
     cmdclass={
         "upload": UploadCommand,
+        "build_py": BuildPyCommand,
     },
 )


### PR DESCRIPTION
Fixes #1129

### Problem
Several helper scripts in `funannotate/aux_scripts` are launched directly via their shebang at runtime (the Perl/shell helpers, `phobius-multiproc.py`, etc.). They are shipped as package data, and a wheel/sdist build does not preserve their execute bit, so after `pip install` the files are mode `0644` and the pipeline fails with permission errors. This is also hit downstream by the Galaxy (galaxyproject/tools-iuc#7267) and bioconda packages.

### Fix
Add a `build_py` subclass that re-asserts the execute bit on the `aux_scripts` in the build output, so the wheel — and therefore the installation — keep them executable regardless of the source file modes.

### Testing
Built a wheel from a source tree with the execute bit stripped (`chmod 0644 funannotate/aux_scripts/*`) and inspected the mode bits stored in the wheel:

| | aux_scripts entries | with `+x` |
|---|---|---|
| without this change | 23 | 0 (all `0644`) |
| with this change | 23 | 23 (all `0755`) |

Existing tests still pass.