### PR TITLE
check: flag an incompatible EvidenceModeler (EVM 2.x) up front

### DIFF
--- a/funannotate/check.py
+++ b/funannotate/check.py
@@ -465,6 +465,20 @@ def main(args):
         print(("All %i environmental variables are set" % (len(variables))))
     print("-------------------------------------------------------")
 
+    # EVM_HOME can be set yet point at an incompatible EvidenceModeler. funannotate
+    # drives the EVM 1.x Perl pipeline (EvmUtils/partition_EVM_inputs.pl); EVM 2.x
+    # dropped those scripts and is not compatible. Without this check the mismatch
+    # only surfaces as a cryptic failure deep inside `funannotate predict`
+    # (see issues #1071, #1072, #1073, #1078). Flag it up front instead.
+    if 'EVM_HOME' not in missing:
+        evm_script = os.path.join(
+            os.environ['EVM_HOME'], 'EvmUtils', 'partition_EVM_inputs.pl')
+        if not os.path.isfile(evm_script):
+            print('\tERROR: $EVM_HOME is set but the EvidenceModeler 1.x scripts were '
+                  'not found\n\t       (EvmUtils/partition_EVM_inputs.pl). funannotate '
+                  'requires EvidenceModeler 1.x;\n\t       EVM 2.x is not compatible.')
+        print("-------------------------------------------------------")
+
     if 'PASAHOME' not in missing:
         LAUNCHPASA = os.path.join(os.environ['PASAHOME'], 'Launch_PASA_pipeline.pl')
         programs2.append(LAUNCHPASA)


### PR DESCRIPTION
### Background
A recurring class of reports (#1071, #1072, #1073, #1078) are conda installs of v1.8.17 where `funannotate predict` fails during Augustus/BUSCO training or EvidenceModeler. One contributing factor, confirmed in #1072, is an incompatible **EvidenceModeler 2.x**: funannotate v1 drives the EVM **1.x** Perl pipeline (`EvmUtils/partition_EVM_inputs.pl`), which EVM 2.x removed.

`funannotate predict` already errors when those scripts are missing, but only deep into a run and with a message that reads like a path problem. Meanwhile `funannotate check` only verified that `$EVM_HOME` was *set*, so it reported *"All environmental variables are set"* even with EVM 2.x — giving false confidence.

### Change
`funannotate check` now also verifies that `$EVM_HOME` contains the EVM 1.x script that `predict.py` relies on, and prints a clear, actionable error if not:

```
ERROR: $EVM_HOME is set but the EvidenceModeler 1.x scripts were not found
       (EvmUtils/partition_EVM_inputs.pl). funannotate requires EvidenceModeler 1.x;
       EVM 2.x is not compatible.
```

This does not change the dependency requirements; it just surfaces the incompatibility at `check` time instead of mid-`predict`. It uses the exact path `predict.py` already checks, so it cannot disagree with the real requirement.

### Testing
In the official Docker image (EVM 1.1.1): `funannotate check` prints **no** EVM error. With `EVM_HOME` pointed at a directory lacking the 1.x scripts (simulating EVM 2.x): the new error is printed. Existing tests still pass.

> Note: this addresses the EVM side only; the Augustus-version factor discussed in #1072 is separate, so I'm referencing rather than claiming to fully close those issues.