### PR TITLE
fix: use full args.cpus for Trinity-GG Butterfly assembly pool

### DIFF
--- a/funannotate/aux_scripts/trinity.py
+++ b/funannotate/aux_scripts/trinity.py
@@ -110,8 +110,8 @@ def runTrinityGG(genome, readTuple, longReads, shortBAM, output, args=False):
             line = line.replace('"', '')  # don't need these double quotes
             file_list.append(line)
     lib.log.info("Assembling "+"{0:,}".format(len(file_list)) +
-                 " Trinity clusters using %i CPUs" % (args.cpus-1))
-    lib.runMultiProgress(safe_run, file_list, args.cpus-1, progress=args.progress)
+                 " Trinity clusters using %i CPUs" % (args.cpus))
+    lib.runMultiProgress(safe_run, file_list, args.cpus, progress=args.progress)
 
     # collected output files and clean
     outputfiles = os.path.join(


### PR DESCRIPTION
Fixes #1178

`runMultiProgress()`'s `cpus` argument becomes the literal
`multiprocessing.Pool(cpus)` size, and each Butterfly job (`worker()`) is
itself a single-threaded `Trinity` subprocess call — so the pool width was
the *only* source of parallelism for this stage. Sizing it at
`args.cpus - 1` meant `--cpus 2` (our production attempt-1 allocation) ran
this stage fully serial (`Pool(1)`), and `--cpus 1` would raise (`Pool(0)`).

## Change

`args.cpus - 1` → `args.cpus` for both the log message and the
`runMultiProgress()` pool size in `funannotate/aux_scripts/trinity.py`.

## Test plan

- [ ] Run `funannotate train` on a small test genome with `--cpus 2` and
      `--cpus 4`/`8`, confirm Butterfly stage wall-clock drops roughly in
      proportion and no regression in output transcript counts.
- [ ] Confirm `--cpus 1` no longer raises on `Pool(0)`.