### PR TITLE
fix: correct operator-precedence bug in bamthreads calculation

### DIFF
--- a/funannotate/aux_scripts/trinity.py
+++ b/funannotate/aux_scripts/trinity.py
@@ -51,7 +51,7 @@ def runTrinityGG(genome, readTuple, longReads, shortBAM, output, args=False):
         lib.log.info("Aligning reads to genome using Hisat2")
         # use bash wrapper for samtools piping for SAM -> BAM -> sortedBAM
         # use half number of threads for bam compression threads
-        bamthreads = (args.cpus + 2 // 2) // 2
+        bamthreads = max(1, args.cpus // 2)
         if args.stranded != 'no' and not readTuple[2]:
             hisat2cmd = ['hisat2', '-p', str(args.cpus), '--max-intronlen',
                          str(args.max_intronlen), '--dta',


### PR DESCRIPTION
Fixes #1179

`(args.cpus + 2 // 2) // 2` evaluates `2 // 2` first, so it actually
computes `(args.cpus + 1) // 2`, not the `(args.cpus + 2) // 2` the spacing
implies was intended. Harmless at `--cpus 2` (both give `1`), diverges at
higher CPU counts.

## Change

Replaced with `max(1, args.cpus // 2)`, matching the "use half number of
threads for bam compression threads" comment directly above it, and
guaranteeing at least 1 `samtools sort` compression thread at any `--cpus`
value (including `--cpus 1`, which previously also produced `1` here by
coincidence but not by guarantee).

## Test plan

- [ ] Run `funannotate train --cpus 4` and `--cpus 8`, confirm
      `samtools sort -@ N` gets the expected thread count in the hisat2 |
      samtools debug log line.