### PR TITLE
Funannotate from BioConda currently works with Python 3.11 too

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -44,7 +44,7 @@ The pipeline can be installed with conda (via [bioconda](https://bioconda.github
     conda config --add channels conda-forge
 
     #then create environment
-    conda create -n funannotate "python>=3.6,<3.9" funannotate
+    conda create -n funannotate "python>=3.6,<3.12" funannotate
 
 If `conda` is taking forever to solve the environment, I would recommend giving [mamba](https://github.com/mamba-org/mamba) a try:
 


### PR DESCRIPTION
This should work nowadays - as per the versions in `setup.py`:

```
$ conda create -n funannotate "python>=3.6,<3.12" funannotate
...
```

It was very slow to execute the transaction, but that installed with python 3.11.15 for me.

<details>

```
$ conda create -n funannotate "python>=3.6,<3.12" funannotate
Retrieving notices: done
Channels:
 - conda-forge
 - bioconda
 - nodefaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /mnt/apps/users/pcock/conda/envs/funannotate

  added / updated specs:
    - funannotate
    - python[version='>=3.6,<3.12']


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    _x86_64-microarch-level-4  |           3_zen4          10 KB  conda-forge
    binutils_linux-64-2.46.1   |default_h4852527_102          35 KB  conda-forge
    gcc_impl_linux-64-13.4.0   |      h649a46b_20        67.1 MB  conda-forge
    gcc_linux-64-13.4.0        |      h5174b15_28          29 KB  conda-forge
    gfortran_impl_linux-64-13.4.0|      hf6af514_20        16.3 MB  conda-forge
    gxx_impl_linux-64-13.4.0   |      h5415f34_20        13.4 MB  conda-forge
    libabseil-20240116.2       | cxx17_he02047a_1         1.2 MB  conda-forge
    libgcc-devel_linux-64-13.4.0|     hd1d28cc_120         2.7 MB  conda-forge
    libprotobuf-4.25.3         |       hd5b35b9_1         2.7 MB  conda-forge
    libsanitizer-13.4.0        |      hf18ac3d_20         6.2 MB  conda-forge
    libstdcxx-devel_linux-64-13.4.0|     h6963c3b_120        18.1 MB  conda-forge
    mysql-8.4.2                |       h27aab58_0         169 KB  conda-forge
    mysql-client-8.4.2         |       ha479ceb_0         4.0 MB  conda-forge
    mysql-common-8.4.2         |       h70512c7_0         608 KB  conda-forge
    mysql-devel-8.4.2          |       h70512c7_0         1.6 MB  conda-forge
    mysql-libs-8.4.2           |       ha479ceb_0         1.3 MB  conda-forge
    mysql-server-8.4.2         |       hcd6732d_0        18.5 MB  conda-forge
    perl-dbd-mysql-5.013       | pl5321h0a44790_0         211 KB  bioconda
    perl-devel-checklib-1.16   | pl5321h7b50bb2_1          19 KB  bioconda
    ------------------------------------------------------------
                                           Total:       154.1 MB

The following NEW packages will be INSTALLED:

  _openmp_mutex      conda-forge/linux-64::_openmp_mutex-4.5-20_gnu
  _r-mutex           conda-forge/noarch::_r-mutex-1.0.1-anacondar_1
  _x86_64-microarch~ conda-forge/noarch::_x86_64-microarch-level-4-3_zen4
  adwaita-icon-theme conda-forge/noarch::adwaita-icon-theme-49.0-unix_0
  alsa-lib           conda-forge/linux-64::alsa-lib-1.2.16.1-hb03c661_0
  argcomplete        conda-forge/noarch::argcomplete-3.7.0-pyhcf101f3_0
  at-spi2-atk        conda-forge/linux-64::at-spi2-atk-2.38.0-h0630a04_3
  at-spi2-core       conda-forge/linux-64::at-spi2-core-2.40.3-h0630a04_0
  atk-1.0            conda-forge/linux-64::atk-1.0-2.38.0-h04ea711_2
  augustus           bioconda/linux-64::augustus-3.5.0-pl5321h57ba348_8
  backports.zstd     conda-forge/linux-64::backports.zstd-1.6.0-py311h6b1f9c4_0
  bamtools           bioconda/linux-64::bamtools-2.5.3-he132191_0
  bedtools           bioconda/linux-64::bedtools-2.31.1-h13024bc_3
  binutils_impl_lin~ conda-forge/linux-64::binutils_impl_linux-64-2.46.1-default_hfdba357_102
  binutils_linux-64  conda-forge/linux-64::binutils_linux-64-2.46.1-default_h4852527_102
  bioconductor-anno~ bioconda/noarch::bioconductor-annotate-1.88.0-r45hdfd78af_0
  bioconductor-anno~ bioconda/noarch::bioconductor-annotationdbi-1.72.0-r45hdfd78af_0
  bioconductor-biob~ bioconda/linux-64::bioconductor-biobase-2.70.0-r45h01b2380_0
  bioconductor-bioc~ bioconda/noarch::bioconductor-biocfilecache-3.0.0-r45hdfd78af_0
  bioconductor-bioc~ bioconda/noarch::bioconductor-biocgenerics-0.56.0-r45hdfd78af_2
  bioconductor-bioc~ bioconda/noarch::bioconductor-biocio-1.20.0-r45hdfd78af_0
  bioconductor-bioc~ bioconda/linux-64::bioconductor-biocparallel-1.44.0-r45ha27e39d_1
  bioconductor-biom~ bioconda/noarch::bioconductor-biomart-2.66.1-r45hdfd78af_0
  bioconductor-bios~ bioconda/linux-64::bioconductor-biostrings-2.78.0-r45h01b2380_0
  bioconductor-ciga~ bioconda/linux-64::bioconductor-cigarillo-1.0.0-r45h01b2380_0
  bioconductor-ctc   bioconda/noarch::bioconductor-ctc-1.84.0-r45hdfd78af_0
  bioconductor-data~ bioconda/noarch::bioconductor-data-packages-20260207-hdfd78af_1
  bioconductor-dela~ bioconda/linux-64::bioconductor-delayedarray-0.36.0-r45h01b2380_0
  bioconductor-dese~ bioconda/linux-64::bioconductor-deseq2-1.50.2-r45ha27e39d_0
  bioconductor-dexs~ bioconda/noarch::bioconductor-dexseq-1.56.0-r45hdfd78af_0
  bioconductor-edger bioconda/linux-64::bioconductor-edger-4.8.2-r45h262fe30_1
  bioconductor-gene~ bioconda/linux-64::bioconductor-genefilter-1.92.0-r45h9e4a190_0
  bioconductor-gene~ bioconda/noarch::bioconductor-genelendatabase-1.46.0-r45hdfd78af_0
  bioconductor-gene~ bioconda/noarch::bioconductor-geneplotter-1.88.0-r45hdfd78af_0
  bioconductor-geno~ bioconda/noarch::bioconductor-genomeinfodb-1.46.2-r45hdfd78af_0
  bioconductor-geno~ bioconda/linux-64::bioconductor-genomicalignments-1.46.0-r45h01b2380_0
  bioconductor-geno~ bioconda/noarch::bioconductor-genomicfeatures-1.62.0-r45hdfd78af_0
  bioconductor-geno~ bioconda/linux-64::bioconductor-genomicranges-1.62.1-r45h01b2380_0
  bioconductor-go.db bioconda/noarch::bioconductor-go.db-3.22.0-r45hdfd78af_0
  bioconductor-goseq bioconda/noarch::bioconductor-goseq-1.62.0-r45hdfd78af_0
  bioconductor-iran~ bioconda/linux-64::bioconductor-iranges-2.44.0-r45h01b2380_1
  bioconductor-kegg~ bioconda/noarch::bioconductor-keggrest-1.50.0-r45hdfd78af_0
  bioconductor-limma bioconda/linux-64::bioconductor-limma-3.66.0-r45h01b2380_0
  bioconductor-matr~ bioconda/noarch::bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1
  bioconductor-qval~ bioconda/noarch::bioconductor-qvalue-2.42.0-r45hdfd78af_0
  bioconductor-rhts~ bioconda/linux-64::bioconductor-rhtslib-3.6.0-r45h01b2380_0
  bioconductor-rsam~ bioconda/linux-64::bioconductor-rsamtools-2.26.0-r45ha27e39d_0
  bioconductor-rtra~ bioconda/linux-64::bioconductor-rtracklayer-1.70.1-r45h01b2380_0
  bioconductor-s4ar~ bioconda/linux-64::bioconductor-s4arrays-1.10.1-r45h01b2380_0
  bioconductor-s4ve~ bioconda/linux-64::bioconductor-s4vectors-0.48.0-r45h01b2380_1
  bioconductor-seqi~ bioconda/noarch::bioconductor-seqinfo-1.0.0-r45hdfd78af_0
  bioconductor-seql~ bioconda/noarch::bioconductor-seqlogo-1.76.0-r45hdfd78af_0
  bioconductor-spar~ bioconda/linux-64::bioconductor-sparsearray-1.10.8-r45h01b2380_0
  bioconductor-summ~ bioconda/noarch::bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0
  bioconductor-txdb~ bioconda/noarch::bioconductor-txdbmaker-1.6.2-r45hdfd78af_0
  bioconductor-ucsc~ bioconda/noarch::bioconductor-ucsc.utils-1.6.1-r45hdfd78af_0
  bioconductor-xvec~ bioconda/linux-64::bioconductor-xvector-0.50.0-r45h01b2380_0
  biopython          conda-forge/linux-64::biopython-1.79-py311hd4cff14_3
  blast              bioconda/linux-64::blast-2.17.0-h66d330f_0
  boost-cpp          conda-forge/linux-64::boost-cpp-1.85.0-h3c6214e_4
  bowtie2            bioconda/linux-64::bowtie2-2.5.5-ha27dd3b_0
  brotli             conda-forge/linux-64::brotli-1.2.0-hed03a55_1
  brotli-bin         conda-forge/linux-64::brotli-bin-1.2.0-hb03c661_1
  brotli-python      conda-forge/linux-64::brotli-python-1.2.0-py311h66f275b_1
  bwidget            conda-forge/linux-64::bwidget-1.10.1-ha770c72_1
  bzip2              conda-forge/linux-64::bzip2-1.0.8-hda65f42_9
  c-ares             conda-forge/linux-64::c-ares-1.34.8-hb03c661_0
  ca-certificates    conda-forge/noarch::ca-certificates-2026.7.22-hbd8a1cb_0
  cairo              conda-forge/linux-64::cairo-1.18.4-h3394656_0
  cdbtools           bioconda/linux-64::cdbtools-0.99-h077b44d_12
  certifi            conda-forge/noarch::certifi-2026.7.22-pyhd8ed1ab_0
  charset-normalizer conda-forge/noarch::charset-normalizer-3.4.9-pyhd8ed1ab_0
  codingquarry       bioconda/linux-64::codingquarry-2.0-py311he264feb_11
  contourpy          conda-forge/linux-64::contourpy-1.3.3-py311h724c32c_4
  coreutils          conda-forge/linux-64::coreutils-9.5-hd590300_0
  curl               conda-forge/linux-64::curl-8.18.0-h4e3cde8_0
  cycler             conda-forge/noarch::cycler-0.12.1-pyhcf101f3_2
  cyrus-sasl         conda-forge/linux-64::cyrus-sasl-2.1.28-hd9c7081_0
  dbus               conda-forge/linux-64::dbus-1.16.2-h24cb091_1
  diamond            bioconda/linux-64::diamond-2.2.4-he361c42_0
  distro             conda-forge/noarch::distro-1.9.0-pyhd8ed1ab_1
  docopt-ng          conda-forge/noarch::docopt-ng-0.9.0-pyhd8ed1ab_1
  entrez-direct      bioconda/linux-64::entrez-direct-24.0-he881be0_0
  epoxy              conda-forge/linux-64::epoxy-1.5.10-hb03c661_2
  et_xmlfile         conda-forge/noarch::et_xmlfile-2.0.0-pyhd8ed1ab_1
  ete3               conda-forge/noarch::ete3-3.1.3-pyhd8ed1ab_0
  evidencemodeler    bioconda/noarch::evidencemodeler-1.1.1-hdfd78af_3
  exonerate          bioconda/linux-64::exonerate-2.4.0-hf34a1b8_9
  expat              conda-forge/linux-64::expat-2.8.1-hecca717_1
  fasta3             bioconda/linux-64::fasta3-36.3.8-hec16e2b_7
  font-ttf-dejavu-s~ conda-forge/noarch::font-ttf-dejavu-sans-mono-2.37-hab24e00_0
  font-ttf-inconsol~ conda-forge/noarch::font-ttf-inconsolata-3.000-h77eed37_0
  font-ttf-source-c~ conda-forge/noarch::font-ttf-source-code-pro-2.038-h77eed37_0
  font-ttf-ubuntu    conda-forge/noarch::font-ttf-ubuntu-0.83-h77eed37_3
  fontconfig         conda-forge/linux-64::fontconfig-2.18.2-h27c8c51_0
  fonts-conda-ecosy~ conda-forge/noarch::fonts-conda-ecosystem-1-0
  fonts-conda-forge  conda-forge/noarch::fonts-conda-forge-1-hc364b38_1
  fonttools          conda-forge/linux-64::fonttools-4.63.0-py311h3778330_0
  freetype           conda-forge/linux-64::freetype-2.14.3-ha770c72_0
  fribidi            conda-forge/linux-64::fribidi-1.0.16-hb03c661_0
  ftpretty           conda-forge/noarch::ftpretty-0.4.0-pyhd8ed1ab_1
  funannotate        bioconda/noarch::funannotate-1.8.17-pyhdfd78af_5
  gawk               conda-forge/linux-64::gawk-5.4.1-h0a3468a_0
  gcc_impl_linux-64  conda-forge/linux-64::gcc_impl_linux-64-13.4.0-h649a46b_20
  gcc_linux-64       conda-forge/linux-64::gcc_linux-64-13.4.0-h5174b15_28
  gdk-pixbuf         conda-forge/linux-64::gdk-pixbuf-2.44.7-h2b0a6b4_0
  gfortran_impl_lin~ conda-forge/linux-64::gfortran_impl_linux-64-13.4.0-hf6af514_20
  giflib             conda-forge/linux-64::giflib-5.2.2-ha257d8a_1
  glib               conda-forge/linux-64::glib-2.88.2-hbe0478d_0
  glib-tools         conda-forge/linux-64::glib-tools-2.88.2-h8094192_0
  glimmerhmm         bioconda/linux-64::glimmerhmm-3.0.4-pl5321h503566f_10
  glpk               conda-forge/linux-64::glpk-5.0-h445213a_0
  gmap               bioconda/linux-64::gmap-2025.07.31-pl5321hb1d24b7_1
  gmp                conda-forge/linux-64::gmp-6.3.0-hac33072_2
  gnutls             conda-forge/linux-64::gnutls-3.8.13-h18acefa_0
  goatools           conda-forge/noarch::goatools-1.6.4-pyhd8ed1ab_0
  graphite2          conda-forge/linux-64::graphite2-1.3.15-hecca717_0
  graphviz           conda-forge/linux-64::graphviz-14.1.2-h8b86629_0
  gsl                conda-forge/linux-64::gsl-2.7-he838d99_0
  gst-plugins-base   conda-forge/linux-64::gst-plugins-base-1.24.11-h651a532_0
  gstreamer          conda-forge/linux-64::gstreamer-1.24.11-hc37bda9_0
  gtk3               conda-forge/linux-64::gtk3-3.24.43-h993cebd_6
  gts                conda-forge/linux-64::gts-0.7.6-h977cf35_4
  gxx_impl_linux-64  conda-forge/linux-64::gxx_impl_linux-64-13.4.0-h5415f34_20
  h2                 conda-forge/noarch::h2-4.4.0-pyhcf101f3_0
  harfbuzz           conda-forge/linux-64::harfbuzz-12.2.0-h15599e2_0
  hdf5               conda-forge/linux-64::hdf5-1.14.3-nompi_h2d575fe_109
  hicolor-icon-theme conda-forge/linux-64::hicolor-icon-theme-0.17-ha770c72_3
  hisat2             bioconda/linux-64::hisat2-2.2.2-h503566f_0
  hmmer              bioconda/linux-64::hmmer-3.4-hb6cb901_4
  hpack              conda-forge/noarch::hpack-4.2.0-pyhd8ed1ab_0
  htslib             bioconda/linux-64::htslib-1.23-h566b1c6_0
  hyperframe         conda-forge/noarch::hyperframe-6.1.0-pyhd8ed1ab_0
  icu                conda-forge/linux-64::icu-75.1-he02047a_0
  idna               conda-forge/noarch::idna-3.18-pyhcf101f3_0
  infernal           bioconda/linux-64::infernal-1.1.5-pl5321h7b50bb2_4
  joblib             conda-forge/noarch::joblib-1.5.3-pyhd8ed1ab_0
  jq                 conda-forge/linux-64::jq-1.8.2-h280c20c_0
  jsoncpp            conda-forge/linux-64::jsoncpp-1.9.6-hf42df4d_1
  k8                 bioconda/linux-64::k8-1.2-he8db53b_6
  kallisto           bioconda/linux-64::kallisto-0.46.1-h6f0a7f7_1
  kernel-headers_li~ conda-forge/noarch::kernel-headers_linux-64-5.14.0-he073ed8_3
  keyutils           conda-forge/linux-64::keyutils-1.6.3-hb9d3cd8_0
  kiwisolver         conda-forge/linux-64::kiwisolver-1.5.0-py311h724c32c_0
  kmer-jellyfish     bioconda/linux-64::kmer-jellyfish-2.3.1-py311pl5321he264feb_6
  krb5               conda-forge/linux-64::krb5-1.21.3-h659f571_0
  lame               conda-forge/linux-64::lame-3.100-h166bdaf_1003
  lcms2              conda-forge/linux-64::lcms2-2.19.1-h0c24ade_1
  ld_impl_linux-64   conda-forge/linux-64::ld_impl_linux-64-2.46.1-default_hbd61a6d_102
  lerc               conda-forge/linux-64::lerc-4.2.0-hdb68285_0
  libabseil          conda-forge/linux-64::libabseil-20240116.2-cxx17_he02047a_1
  libaec             conda-forge/linux-64::libaec-1.1.5-h088129d_0
  libamd             conda-forge/linux-64::libamd-3.3.3-haaf9dc3_7100102
  libasprintf        conda-forge/linux-64::libasprintf-0.25.1-h3f43e3d_1
  libblas            conda-forge/linux-64::libblas-3.11.0-8_h4a7cf45_openblas
  libboost           conda-forge/linux-64::libboost-1.85.0-h0ccab89_4
  libboost-devel     conda-forge/linux-64::libboost-devel-1.85.0-h00ab1b0_4
  libboost-headers   conda-forge/linux-64::libboost-headers-1.85.0-ha770c72_4
  libbrotlicommon    conda-forge/linux-64::libbrotlicommon-1.2.0-hb03c661_1
  libbrotlidec       conda-forge/linux-64::libbrotlidec-1.2.0-hb03c661_1
  libbrotlienc       conda-forge/linux-64::libbrotlienc-1.2.0-hb03c661_1
  libbtf             conda-forge/linux-64::libbtf-2.3.2-h32481e8_7100102
  libcamd            conda-forge/linux-64::libcamd-3.3.3-h32481e8_7100102
  libcap             conda-forge/linux-64::libcap-2.78-hd0affe5_0
  libcblas           conda-forge/linux-64::libcblas-3.11.0-8_h0358290_openblas
  libccolamd         conda-forge/linux-64::libccolamd-3.3.4-h32481e8_7100102
  libcholmod         conda-forge/linux-64::libcholmod-5.3.1-h59ddab4_7100102
  libclang-cpp21.1   conda-forge/linux-64::libclang-cpp21.1-21.1.8-default_h99862b1_4
  libclang-cpp22.1   conda-forge/linux-64::libclang-cpp22.1-22.1.8-default_h6c227bf_3
  libclang13         conda-forge/linux-64::libclang13-22.1.8-default_h9692865_3
  libcolamd          conda-forge/linux-64::libcolamd-3.3.4-h32481e8_7100102
  libcups            conda-forge/linux-64::libcups-2.3.3-hb8b1518_5
  libcurl            conda-forge/linux-64::libcurl-8.18.0-h4e3cde8_0
  libcxsparse        conda-forge/linux-64::libcxsparse-4.4.1-h32481e8_7100102
  libdb              conda-forge/linux-64::libdb-6.2.32-h9c3ff4c_0
  libdeflate         conda-forge/linux-64::libdeflate-1.25-h17f619e_0
  libdrm             conda-forge/linux-64::libdrm-2.4.127-hb03c661_0
  libedit            conda-forge/linux-64::libedit-3.1.20250104-pl5321h7949ede_0
  libegl             conda-forge/linux-64::libegl-1.7.0-ha4b6fd6_3
  libegl-devel       conda-forge/linux-64::libegl-devel-1.7.0-ha4b6fd6_3
  libev              conda-forge/linux-64::libev-4.33-hd590300_2
  libevent           conda-forge/linux-64::libevent-2.1.12-hf998b51_1
  libexpat           conda-forge/linux-64::libexpat-2.8.1-hecca717_1
  libffi             conda-forge/linux-64::libffi-3.5.2-h3435931_0
  libflac            conda-forge/linux-64::libflac-1.5.0-he200343_1
  libfreetype        conda-forge/linux-64::libfreetype-2.14.3-ha770c72_0
  libfreetype6       conda-forge/linux-64::libfreetype6-2.14.3-h73754d4_0
  libgcc             conda-forge/linux-64::libgcc-16.1.0-ha9f2e26_0
  libgcc-devel_linu~ conda-forge/noarch::libgcc-devel_linux-64-13.4.0-hd1d28cc_120
  libgcc-ng          conda-forge/linux-64::libgcc-ng-16.1.0-h69a702a_0
  libgd              conda-forge/linux-64::libgd-2.3.3-h6f5c62b_11
  libgettextpo       conda-forge/linux-64::libgettextpo-0.25.1-h3f43e3d_1
  libgfortran        conda-forge/linux-64::libgfortran-16.1.0-h69a702a_0
  libgfortran-ng     conda-forge/linux-64::libgfortran-ng-16.1.0-h69a702a_0
  libgfortran5       conda-forge/linux-64::libgfortran5-16.1.0-h79bb938_0
  libgl              conda-forge/linux-64::libgl-1.7.0-ha4b6fd6_3
  libgl-devel        conda-forge/linux-64::libgl-devel-1.7.0-ha4b6fd6_3
  libglib            conda-forge/linux-64::libglib-2.88.2-h0d30a3d_0
  libglvnd           conda-forge/linux-64::libglvnd-1.7.0-ha4b6fd6_3
  libglx             conda-forge/linux-64::libglx-1.7.0-ha4b6fd6_3
  libglx-devel       conda-forge/linux-64::libglx-devel-1.7.0-ha4b6fd6_3
  libgomp            conda-forge/linux-64::libgomp-16.1.0-he0feb66_0
  libiconv           conda-forge/linux-64::libiconv-1.18-h3b78370_2
  libidn11           conda-forge/linux-64::libidn11-1.34-h1cef754_0
  libidn2            conda-forge/linux-64::libidn2-2.3.8-hfac485b_1
  libjpeg-turbo      conda-forge/linux-64::libjpeg-turbo-3.2.0-hb03c661_0
  libklu             conda-forge/linux-64::libklu-2.3.5-hf24d653_7100102
  liblapack          conda-forge/linux-64::liblapack-3.11.0-8_h47877c9_openblas
  liblapacke         conda-forge/linux-64::liblapacke-3.11.0-8_h6ae95b6_openblas
  libldl             conda-forge/linux-64::libldl-3.3.2-h32481e8_7100102
  libllvm21          conda-forge/linux-64::libllvm21-21.1.8-hf7376ad_0
  libllvm22          conda-forge/linux-64::libllvm22-22.1.8-hf7376ad_1
  liblzma            conda-forge/linux-64::liblzma-5.8.3-hb03c661_0
  liblzma-devel      conda-forge/linux-64::liblzma-devel-5.8.3-hb03c661_0
  libnghttp2         conda-forge/linux-64::libnghttp2-1.68.1-h877daf1_0
  libnsl             conda-forge/linux-64::libnsl-2.0.1-hb9d3cd8_1
  libntlm            conda-forge/linux-64::libntlm-1.8-hb9d3cd8_0
  libogg             conda-forge/linux-64::libogg-1.3.5-hd0c01bc_1
  libopenblas        conda-forge/linux-64::libopenblas-0.3.33-pthreads_h94d23a6_0
  libopengl          conda-forge/linux-64::libopengl-1.7.0-ha4b6fd6_3
  libopenssl-static  conda-forge/linux-64::libopenssl-static-3.6.3-hb03c661_0
  libopus            conda-forge/linux-64::libopus-1.6.1-h280c20c_0
  libparu            conda-forge/linux-64::libparu-1.0.0-h17147ab_7100102
  libpciaccess       conda-forge/linux-64::libpciaccess-0.19-hb03c661_0
  libpng             conda-forge/linux-64::libpng-1.6.58-h421ea60_0
  libpq              conda-forge/linux-64::libpq-18.1-h5c52fec_2
  libprotobuf        conda-forge/linux-64::libprotobuf-4.25.3-hd5b35b9_1
  librbio            conda-forge/linux-64::librbio-4.3.4-h32481e8_7100102
  librsvg            conda-forge/linux-64::librsvg-2.60.2-h61e6d4b_0
  libsanitizer       conda-forge/linux-64::libsanitizer-13.4.0-hf18ac3d_20
  libsndfile         conda-forge/linux-64::libsndfile-1.2.2-hc7d488a_2
  libspex            conda-forge/linux-64::libspex-3.2.3-had10066_7100102
  libspqr            conda-forge/linux-64::libspqr-4.3.4-h852d39f_7100102
  libsqlite          conda-forge/linux-64::libsqlite-3.53.4-h0c1763c_0
  libssh2            conda-forge/linux-64::libssh2-1.11.1-hcf80075_0
  libstdcxx          conda-forge/linux-64::libstdcxx-16.1.0-h934c35e_0
  libstdcxx-devel_l~ conda-forge/noarch::libstdcxx-devel_linux-64-13.4.0-h6963c3b_120
  libstdcxx-ng       conda-forge/linux-64::libstdcxx-ng-16.1.0-hdf11a46_0
  libsuitesparsecon~ conda-forge/linux-64::libsuitesparseconfig-7.10.1-h92d6892_7100102
  libsystemd0        conda-forge/linux-64::libsystemd0-261.1-h6f4a2f1_0
  libtasn1           conda-forge/linux-64::libtasn1-4.21.0-hb03c661_0
  libtiff            conda-forge/linux-64::libtiff-4.7.2-h9d88235_0
  libumfpack         conda-forge/linux-64::libumfpack-6.3.5-heb53515_7100102
  libunistring       conda-forge/linux-64::libunistring-0.9.10-h7f98852_0
  libuuid            conda-forge/linux-64::libuuid-2.42.2-h5347b49_0
  libuv              conda-forge/linux-64::libuv-1.52.1-h280c20c_0
  libvorbis          conda-forge/linux-64::libvorbis-1.3.7-h54a6638_2
  libwebp-base       conda-forge/linux-64::libwebp-base-1.6.0-hd42ef1d_0
  libxcb             conda-forge/linux-64::libxcb-1.17.0-h8a09558_0
  libxcrypt          conda-forge/linux-64::libxcrypt-4.4.36-hd590300_1
  libxkbcommon       conda-forge/linux-64::libxkbcommon-1.13.2-hca5e8e5_0
  libxml2            conda-forge/linux-64::libxml2-2.15.1-h26afc86_0
  libxml2-16         conda-forge/linux-64::libxml2-16-2.15.1-ha9997c6_0
  libxml2-devel      conda-forge/linux-64::libxml2-devel-2.15.1-h26afc86_0
  libxslt            conda-forge/linux-64::libxslt-1.1.43-h711ed8c_1
  libzlib            conda-forge/linux-64::libzlib-1.3.2-h25fd6f3_2
  lighttpd           conda-forge/linux-64::lighttpd-1.4.79-lua54h2feac79_0
  lp_solve           conda-forge/linux-64::lp_solve-5.5.2.11-hd590300_0
  lua                conda-forge/linux-64::lua-5.4.8-h03e1676_1
  lxml               conda-forge/linux-64::lxml-6.1.1-py311h8840267_0
  lz4-c              conda-forge/linux-64::lz4-c-1.9.4-hcb278e6_0
  mafft              conda-forge/linux-64::mafft-7.526-h4bc722e_0
  make               conda-forge/linux-64::make-4.4.1-hb9d3cd8_2
  mariadb-connector~ conda-forge/linux-64::mariadb-connector-c-3.4.8-h6dee460_0
  markdown-it-py     conda-forge/noarch::markdown-it-py-4.2.0-pyhd8ed1ab_0
  matplotlib-base    conda-forge/linux-64::matplotlib-base-3.10.9-py311h0f3be63_0
  mdurl              conda-forge/noarch::mdurl-0.1.2-pyhd8ed1ab_1
  metis              conda-forge/linux-64::metis-5.1.0-hd0bcaf9_1007
  minimap2           bioconda/linux-64::minimap2-2.31-h118bc1c_0
  mpfr               conda-forge/linux-64::mpfr-4.2.2-he0a73b1_0
  mpg123             conda-forge/linux-64::mpg123-1.32.9-hc50e24c_0
  mpi                conda-forge/linux-64::mpi-1.0-openmpi
  munkres            conda-forge/noarch::munkres-1.1.4-pyhd8ed1ab_1
  mysql              conda-forge/linux-64::mysql-8.4.2-h27aab58_0
  mysql-client       conda-forge/linux-64::mysql-client-8.4.2-ha479ceb_0
  mysql-common       conda-forge/linux-64::mysql-common-8.4.2-h70512c7_0
  mysql-connector-c  conda-forge/linux-64::mysql-connector-c-6.1.11-h659d440_1008
  mysql-devel        conda-forge/linux-64::mysql-devel-8.4.2-h70512c7_0
  mysql-libs         conda-forge/linux-64::mysql-libs-8.4.2-ha479ceb_0
  mysql-server       conda-forge/linux-64::mysql-server-8.4.2-hcd6732d_0
  narwhals           conda-forge/noarch::narwhals-2.24.0-pyhcf101f3_0
  natsort            conda-forge/noarch::natsort-8.4.0-pyhcf101f3_2
  ncbi-vdb           bioconda/linux-64::ncbi-vdb-3.4.1-hd63eeec_0
  ncurses            conda-forge/linux-64::ncurses-6.6-hdb14827_0
  nettle             conda-forge/linux-64::nettle-3.10.1-h4a9d5aa_0
  nspr               conda-forge/linux-64::nspr-4.38-h29cc59b_0
  nss                conda-forge/linux-64::nss-3.118-h445c969_0
  numpy              conda-forge/linux-64::numpy-2.4.6-py311h2e04523_0
  oniguruma          conda-forge/linux-64::oniguruma-6.9.10-hb9d3cd8_0
  openjdk            conda-forge/linux-64::openjdk-25.0.1-h5755bd7_0
  openjpeg           conda-forge/linux-64::openjpeg-2.5.4-h55fea9a_0
  openldap           conda-forge/linux-64::openldap-2.6.10-he970967_0
  openmpi            conda-forge/linux-64::openmpi-4.1.6-hc5af2df_101
  openpyxl           conda-forge/linux-64::openpyxl-3.1.5-py311h534898f_3
  openssl            conda-forge/linux-64::openssl-3.6.3-h35e630c_0
  p11-kit            conda-forge/linux-64::p11-kit-0.26.4-h3435931_0
  packaging          conda-forge/noarch::packaging-26.2-pyhc364b38_0
  pandas             conda-forge/linux-64::pandas-3.0.5-py311h8032f78_1
  pandoc             conda-forge/linux-64::pandoc-3.10.1-ha770c72_0
  pango              conda-forge/linux-64::pango-1.56.4-hadf4263_0
  pasa               bioconda/linux-64::pasa-2.5.3-h9948957_2
  patsy              conda-forge/noarch::patsy-1.0.2-pyhcf101f3_0
  pblat              bioconda/linux-64::pblat-2.5.1-h41f7678_4
  pcre               conda-forge/linux-64::pcre-8.45-h9c3ff4c_0
  pcre2              conda-forge/linux-64::pcre2-10.47-haa7fec5_0
  perl               conda-forge/linux-64::perl-5.32.1-7_hd590300_perl5
  perl-app-cpanminus conda-forge/noarch::perl-app-cpanminus-1.7048-pl5321hd8ed1ab_0
  perl-archive-tar   bioconda/noarch::perl-archive-tar-3.12-pl5321hdfd78af_0
  perl-b-cow         conda-forge/linux-64::perl-b-cow-0.007-pl5321hb9d3cd8_1
  perl-base          conda-forge/noarch::perl-base-2.23-pl5321hd8ed1ab_0
  perl-business-isbn conda-forge/noarch::perl-business-isbn-3.007-pl5321hd8ed1ab_0
  perl-business-isb~ conda-forge/noarch::perl-business-isbn-data-20210112.006-pl5321hd8ed1ab_0
  perl-carp          conda-forge/noarch::perl-carp-1.50-pl5321hd8ed1ab_0
  perl-cgi           bioconda/linux-64::perl-cgi-4.72-pl5321hab16a5f_0
  perl-class-data-i~ conda-forge/linux-64::perl-class-data-inheritable-0.09-pl5321ha770c72_0
  perl-class-inspec~ bioconda/noarch::perl-class-inspector-1.36-pl5321hdfd78af_0
  perl-class-method~ conda-forge/linux-64::perl-class-method-modifiers-2.13-pl5321ha770c72_0
  perl-clone         conda-forge/linux-64::perl-clone-0.46-pl5321hb9d3cd8_1
  perl-clone-choose  conda-forge/noarch::perl-clone-choose-0.010-pl5321hd8ed1ab_0
  perl-common-sense  conda-forge/noarch::perl-common-sense-3.75-pl5321hd8ed1ab_0
  perl-compress-raw~ conda-forge/linux-64::perl-compress-raw-bzip2-2.214-pl5321hda65f42_0
  perl-compress-raw~ conda-forge/linux-64::perl-compress-raw-zlib-2.214-pl5321h4dac143_0
  perl-constant      conda-forge/noarch::perl-constant-1.33-pl5321hd8ed1ab_0
  perl-convert-binh~ bioconda/noarch::perl-convert-binhex-1.125-pl5321hdfd78af_2
  perl-data-dump     bioconda/linux-64::perl-data-dump-1.25-pl5321h7b50bb2_2
  perl-data-dumper   conda-forge/linux-64::perl-data-dumper-2.183-pl5321hb9d3cd8_1
  perl-db_file       conda-forge/linux-64::perl-db_file-1.858-pl5321hb9d3cd8_0
  perl-dbd-mysql     bioconda/linux-64::perl-dbd-mysql-5.013-pl5321h0a44790_0
  perl-dbd-sqlite    bioconda/linux-64::perl-dbd-sqlite-1.78-pl5321h6709bd3_0
  perl-dbi           conda-forge/linux-64::perl-dbi-1.651-pl5321hb03c661_0
  perl-devel-checkl~ bioconda/linux-64::perl-devel-checklib-1.16-pl5321h7b50bb2_1
  perl-devel-stackt~ conda-forge/linux-64::perl-devel-stacktrace-2.04-pl5321h296ab09_0
  perl-digest-hmac   bioconda/noarch::perl-digest-hmac-1.05-pl5321hdfd78af_0
  perl-digest-md5    conda-forge/linux-64::perl-digest-md5-2.59-pl5321hb9d3cd8_3
  perl-email-date-f~ conda-forge/noarch::perl-email-date-format-1.006-pl5321hd8ed1ab_0
  perl-encode        conda-forge/linux-64::perl-encode-3.24-pl5321hb03c661_0
  perl-encode-locale bioconda/noarch::perl-encode-locale-1.05-pl5321hdfd78af_7
  perl-exception-cl~ conda-forge/linux-64::perl-exception-class-1.45-pl5321ha770c72_0
  perl-exporter      conda-forge/noarch::perl-exporter-5.74-pl5321hd8ed1ab_0
  perl-exporter-tiny conda-forge/noarch::perl-exporter-tiny-1.002002-pl5321hd8ed1ab_0
  perl-extutils-mak~ conda-forge/noarch::perl-extutils-makemaker-7.70-pl5321hd8ed1ab_0
  perl-file-listing  bioconda/noarch::perl-file-listing-6.16-pl5321hdfd78af_0
  perl-file-path     conda-forge/noarch::perl-file-path-2.18-pl5321hd8ed1ab_0
  perl-file-spec     bioconda/noarch::perl-file-spec-3.48_01-pl5321hdfd78af_2
  perl-file-temp     conda-forge/noarch::perl-file-temp-0.2304-pl5321hd8ed1ab_0
  perl-file-util     bioconda/noarch::perl-file-util-4.201720-pl5321hdfd78af_0
  perl-file-which    conda-forge/noarch::perl-file-which-1.24-pl5321hd8ed1ab_0
  perl-getopt-long   bioconda/noarch::perl-getopt-long-2.58-pl5321hdfd78af_0
  perl-hash-merge    conda-forge/noarch::perl-hash-merge-0.302-pl5321hd8ed1ab_0
  perl-html-parser   bioconda/linux-64::perl-html-parser-3.85-pl5321hc52dbad_0
  perl-html-tagset   bioconda/noarch::perl-html-tagset-3.24-pl5321hdfd78af_0
  perl-http-cookiej~ bioconda/noarch::perl-http-cookiejar-lwp-0.014-pl5321hdfd78af_0
  perl-http-cookies  bioconda/noarch::perl-http-cookies-6.12-pl5321hdfd78af_0
  perl-http-daemon   bioconda/noarch::perl-http-daemon-6.17-pl5321hdfd78af_0
  perl-http-date     bioconda/noarch::perl-http-date-6.08-pl5321hdfd78af_0
  perl-http-message  bioconda/noarch::perl-http-message-7.04-pl5321hdfd78af_0
  perl-http-negotia~ bioconda/noarch::perl-http-negotiate-6.01-pl5321hdfd78af_4
  perl-inc-latest    conda-forge/linux-64::perl-inc-latest-0.500-pl5321ha770c72_0
  perl-io-compress   bioconda/linux-64::perl-io-compress-2.216-pl5321h503566f_0
  perl-io-html       bioconda/noarch::perl-io-html-1.004-pl5321hdfd78af_0
  perl-io-sessionda~ bioconda/noarch::perl-io-sessiondata-1.03-pl5321hdfd78af_2
  perl-io-socket-ssl conda-forge/noarch::perl-io-socket-ssl-2.075-pl5321hd8ed1ab_0
  perl-io-zlib       bioconda/noarch::perl-io-zlib-1.15-pl5321hdfd78af_1
  perl-json          bioconda/noarch::perl-json-4.11-pl5321hdfd78af_0
  perl-json-xs       bioconda/linux-64::perl-json-xs-4.04-pl5321h9948957_0
  perl-lib           conda-forge/noarch::perl-lib-0.63-pl5321hd8ed1ab_0
  perl-libwww-perl   bioconda/noarch::perl-libwww-perl-6.83-pl5321hdfd78af_0
  perl-list-moreuti~ bioconda/noarch::perl-list-moreutils-0.430-pl5321hdfd78af_0
  perl-list-moreuti~ bioconda/linux-64::perl-list-moreutils-xs-0.430-pl5321h7b50bb2_5
  perl-local-lib     bioconda/noarch::perl-local-lib-2.000029-pl5321hdfd78af_0
  perl-logger-simple bioconda/noarch::perl-logger-simple-2.0-pl5321hdfd78af_1
  perl-lwp-mediatyp~ bioconda/noarch::perl-lwp-mediatypes-6.04-pl5321hdfd78af_1
  perl-lwp-protocol~ bioconda/noarch::perl-lwp-protocol-https-6.17-pl5321hdfd78af_0
  perl-mailtools     bioconda/noarch::perl-mailtools-2.22-pl5321hdfd78af_0
  perl-math-utils    bioconda/noarch::perl-math-utils-1.14-pl5321hdfd78af_0
  perl-mce           bioconda/noarch::perl-mce-1.902-pl5321hdfd78af_0
  perl-mime-base64   conda-forge/linux-64::perl-mime-base64-3.16-pl5321hb9d3cd8_3
  perl-mime-lite     bioconda/noarch::perl-mime-lite-3.030-pl5321hdfd78af_2
  perl-mime-tools    bioconda/noarch::perl-mime-tools-5.517-pl5321hdfd78af_0
  perl-mime-types    bioconda/noarch::perl-mime-types-2.30-pl5321hdfd78af_0
  perl-module-build  conda-forge/linux-64::perl-module-build-0.4234-pl5321ha770c72_1
  perl-module-load   bioconda/noarch::perl-module-load-0.34-pl5321hdfd78af_0
  perl-moo           conda-forge/linux-64::perl-moo-2.005004-pl5321ha770c72_0
  perl-mozilla-ca    bioconda/noarch::perl-mozilla-ca-20250602-pl5321hdfd78af_0
  perl-net-http      bioconda/noarch::perl-net-http-6.24-pl5321hdfd78af_0
  perl-net-ssleay    conda-forge/linux-64::perl-net-ssleay-1.96-pl5321h34fdc24_0
  perl-ntlm          bioconda/noarch::perl-ntlm-1.09-pl5321hdfd78af_5
  perl-object-insid~ bioconda/noarch::perl-object-insideout-4.05-pl5321hdfd78af_1
  perl-parallel-for~ bioconda/noarch::perl-parallel-forkmanager-2.04-pl5321hdfd78af_0
  perl-parent        conda-forge/noarch::perl-parent-0.243-pl5321hd8ed1ab_0
  perl-pathtools     conda-forge/linux-64::perl-pathtools-3.75-pl5321hb9d3cd8_2
  perl-role-tiny     conda-forge/linux-64::perl-role-tiny-2.002004-pl5321ha770c72_0
  perl-scalar-list-~ conda-forge/linux-64::perl-scalar-list-utils-1.70-pl5321hb03c661_0
  perl-scalar-util-~ bioconda/linux-64::perl-scalar-util-numeric-0.40-pl5321h7b50bb2_7
  perl-soap-lite     bioconda/noarch::perl-soap-lite-1.27-pl5321hdfd78af_0
  perl-socket        bioconda/linux-64::perl-socket-2.027-pl5321h5c03b87_6
  perl-storable      conda-forge/linux-64::perl-storable-3.15-pl5321hb9d3cd8_2
  perl-sub-quote     conda-forge/linux-64::perl-sub-quote-2.006006-pl5321ha770c72_0
  perl-task-weaken   bioconda/noarch::perl-task-weaken-1.06-pl5321hdfd78af_1
  perl-test-fatal    conda-forge/linux-64::perl-test-fatal-0.016-pl5321ha770c72_0
  perl-test-harness  conda-forge/noarch::perl-test-harness-3.44-pl5321hd8ed1ab_0
  perl-test-needs    conda-forge/noarch::perl-test-needs-0.002009-pl5321hd8ed1ab_0
  perl-test-nowarni~ conda-forge/linux-64::perl-test-nowarnings-1.06-pl5321ha770c72_0
  perl-test-pod      bioconda/noarch::perl-test-pod-1.52-pl5321hdfd78af_1
  perl-test-require~ bioconda/noarch::perl-test-requiresinternet-0.05-pl5321hdfd78af_1
  perl-test-warnings conda-forge/linux-64::perl-test-warnings-0.031-pl5321ha770c72_0
  perl-text-soundex  conda-forge/noarch::perl-text-soundex-3.05-pl5321hd8ed1ab_1001
  perl-time-hires    bioconda/linux-64::perl-time-hires-1.9764-pl5321h7b50bb2_6
  perl-time-local    bioconda/noarch::perl-time-local-1.35-pl5321hdfd78af_0
  perl-timedate      bioconda/noarch::perl-timedate-2.35-pl5321hdfd78af_0
  perl-try-tiny      conda-forge/linux-64::perl-try-tiny-0.31-pl5321ha770c72_0
  perl-types-serial~ bioconda/noarch::perl-types-serialiser-1.01-pl5321hdfd78af_0
  perl-uri           conda-forge/linux-64::perl-uri-5.35-pl5321ha770c72_0
  perl-url-encode    bioconda/linux-64::perl-url-encode-0.03-pl5321h9ee0642_1
  perl-www-robotrul~ bioconda/noarch::perl-www-robotrules-6.03-pl5321hdfd78af_0
  perl-xml-parser    conda-forge/linux-64::perl-xml-parser-2.44_01-pl5321hf2e2c51_1004
  perl-yaml          bioconda/noarch::perl-yaml-1.30-pl5321hdfd78af_0
  phyml              bioconda/linux-64::phyml-3.3.20220408-h9bc3f66_3
  pigz               conda-forge/linux-64::pigz-2.8-h421ea60_2
  pillow             conda-forge/linux-64::pillow-12.3.0-py311hf88fc01_0
  pip                conda-forge/noarch::pip-26.1.2-pyh8b19718_0
  pixman             conda-forge/linux-64::pixman-0.46.4-h54a6638_2
  ply                conda-forge/noarch::ply-3.11-pyhd8ed1ab_3
  proteinortho       bioconda/linux-64::proteinortho-6.3.6-h2b77389_0
  psutil             conda-forge/linux-64::psutil-7.2.2-py311haee01d2_0
  pthread-stubs      conda-forge/linux-64::pthread-stubs-0.4-hb9d3cd8_1002
  pulseaudio-client  conda-forge/linux-64::pulseaudio-client-17.0-h9a6aba3_3
  pydot              conda-forge/noarch::pydot-4.0.1-pyhcf101f3_2
  pygments           conda-forge/noarch::pygments-2.20.0-pyhd8ed1ab_0
  pyparsing          conda-forge/noarch::pyparsing-3.3.2-pyhcf101f3_0
  pyqt               conda-forge/linux-64::pyqt-5.15.11-py311h0580839_2
  pyqt5-sip          conda-forge/linux-64::pyqt5-sip-12.17.0-py311h1ddb823_2
  pysocks            conda-forge/noarch::pysocks-1.7.1-pyha55dd90_7
  python             conda-forge/linux-64::python-3.11.15-h7508c33_1_cpython
  python-dateutil    conda-forge/noarch::python-dateutil-2.9.0.post0-pyhe01879c_2
  python_abi         conda-forge/noarch::python_abi-3.11-8_cp311
  pyyaml             conda-forge/linux-64::pyyaml-6.0.3-py311h3778330_1
  qhull              conda-forge/linux-64::qhull-2020.2-h434a139_5
  qt-main            conda-forge/linux-64::qt-main-5.15.15-h3c3fd16_6
  r-abind            conda-forge/noarch::r-abind-1.4_8-r45hc72bb7e_1
  r-amap             conda-forge/linux-64::r-amap-0.8_20-r45ha36cffa_1
  r-ape              conda-forge/linux-64::r-ape-5.8_1-r45h3704496_2
  r-argparse         conda-forge/noarch::r-argparse-2.3.1-r45hc72bb7e_0
  r-askpass          conda-forge/linux-64::r-askpass-1.2.1-r45h54b55ab_1
  r-assertthat       conda-forge/noarch::r-assertthat-0.2.1-r45hc72bb7e_6
  r-backports        conda-forge/linux-64::r-backports-1.5.1-r45h54b55ab_0
  r-base             conda-forge/linux-64::r-base-4.5.2-h835929b_3
  r-base64enc        conda-forge/linux-64::r-base64enc-0.1_6-r45h54b55ab_0
  r-bh               conda-forge/noarch::r-bh-1.90.0_1-r45hc72bb7e_0
  r-biasedurn        conda-forge/linux-64::r-biasedurn-2.0.12-r45h3697838_2
  r-bit              conda-forge/linux-64::r-bit-4.6.0-r45h54b55ab_1
  r-bit64            conda-forge/linux-64::r-bit64-4.8.2-r45h54b55ab_0
  r-bitops           conda-forge/linux-64::r-bitops-1.0_9-r45h54b55ab_1
  r-blob             conda-forge/noarch::r-blob-1.3.0-r45hc72bb7e_0
  r-broom            conda-forge/noarch::r-broom-1.0.13-r45hc72bb7e_0
  r-bslib            conda-forge/noarch::r-bslib-0.11.0-r45hc72bb7e_0
  r-cachem           conda-forge/linux-64::r-cachem-1.1.0-r45h54b55ab_2
  r-callr            conda-forge/noarch::r-callr-3.7.6-r45hc72bb7e_2
  r-catools          conda-forge/linux-64::r-catools-1.18.4-r45h3697838_0
  r-cellranger       conda-forge/noarch::r-cellranger-1.1.0-r45hc72bb7e_1008
  r-cli              conda-forge/linux-64::r-cli-3.6.6-r45h3697838_0
  r-clipr            conda-forge/noarch::r-clipr-0.8.1-r45hc72bb7e_0
  r-cluster          conda-forge/linux-64::r-cluster-2.1.8.2-r45heaba542_0
  r-codetools        conda-forge/noarch::r-codetools-0.2_20-r45hc72bb7e_2
  r-colorspace       conda-forge/linux-64::r-colorspace-2.1_3-r45h54b55ab_0
  r-conflicted       conda-forge/noarch::r-conflicted-1.2.0-r45h785f33e_3
  r-cpp11            conda-forge/noarch::r-cpp11-0.5.5-r45h785f33e_0
  r-crayon           conda-forge/noarch::r-crayon-1.5.3-r45hc72bb7e_2
  r-curl             conda-forge/linux-64::r-curl-7.0.0-r45h10955f1_1
  r-data.table       conda-forge/linux-64::r-data.table-1.18.4-r45h1c8cec4_0
  r-dbi              conda-forge/noarch::r-dbi-1.3.0-r45hc72bb7e_0
  r-dbplyr           conda-forge/noarch::r-dbplyr-2.6.0-r45hc72bb7e_0
  r-digest           conda-forge/linux-64::r-digest-0.6.39-r45h3697838_0
  r-dplyr            conda-forge/linux-64::r-dplyr-1.2.1-r45h3697838_0
  r-dtplyr           conda-forge/noarch::r-dtplyr-1.3.3-r45hc72bb7e_0
  r-ellipsis         conda-forge/linux-64::r-ellipsis-0.3.3-r45h54b55ab_0
  r-evaluate         conda-forge/noarch::r-evaluate-1.0.5-r45hc72bb7e_1
  r-fansi            conda-forge/linux-64::r-fansi-1.0.7-r45h54b55ab_0
  r-farver           conda-forge/linux-64::r-farver-2.1.2-r45h3697838_2
  r-fastcluster      conda-forge/linux-64::r-fastcluster-1.3.0-r45h3697838_1
  r-fastmap          conda-forge/linux-64::r-fastmap-1.2.0-r45h3697838_2
  r-fastmatch        conda-forge/linux-64::r-fastmatch-1.1_8-r45h54b55ab_0
  r-filelock         conda-forge/linux-64::r-filelock-1.0.3-r45h54b55ab_2
  r-findpython       conda-forge/noarch::r-findpython-1.0.9-r45hc72bb7e_1
  r-fontawesome      conda-forge/noarch::r-fontawesome-0.5.3-r45hc72bb7e_1
  r-forcats          conda-forge/noarch::r-forcats-1.0.1-r45hc72bb7e_0
  r-formatr          conda-forge/noarch::r-formatr-1.14-r45hc72bb7e_3
  r-fs               conda-forge/linux-64::r-fs-2.1.0-r45h3697838_0
  r-futile.logger    conda-forge/noarch::r-futile.logger-1.4.9-r45hc72bb7e_0
  r-futile.options   conda-forge/noarch::r-futile.options-1.0.1-r45hc72bb7e_1006
  r-gargle           conda-forge/noarch::r-gargle-1.6.1-r45h785f33e_0
  r-generics         conda-forge/noarch::r-generics-0.1.4-r45hc72bb7e_1
  r-ggplot2          conda-forge/noarch::r-ggplot2-4.0.3-r45h785f33e_0
  r-glue             conda-forge/linux-64::r-glue-1.8.1-r45h54b55ab_0
  r-googledrive      conda-forge/noarch::r-googledrive-2.1.2-r45hc72bb7e_1
  r-googlesheets4    conda-forge/noarch::r-googlesheets4-1.1.2-r45h785f33e_1
  r-gplots           conda-forge/noarch::r-gplots-3.3.0-r45hc72bb7e_0
  r-gtable           conda-forge/noarch::r-gtable-0.3.6-r45hc72bb7e_1
  r-gtools           conda-forge/linux-64::r-gtools-3.9.5-r45h54b55ab_2
  r-haven            conda-forge/linux-64::r-haven-2.5.5-r45h6d565e7_1
  r-highr            conda-forge/noarch::r-highr-0.12-r45hc72bb7e_0
  r-hms              conda-forge/noarch::r-hms-1.1.4-r45hc72bb7e_0
  r-htmltools        conda-forge/linux-64::r-htmltools-0.5.9-r45h3697838_0
  r-httr             conda-forge/noarch::r-httr-1.4.8-r45hc72bb7e_0
  r-httr2            conda-forge/noarch::r-httr2-1.3.0-r45hc72bb7e_0
  r-hwriter          conda-forge/noarch::r-hwriter-1.3.2.1-r45hc72bb7e_4
  r-ids              conda-forge/noarch::r-ids-1.0.1-r45hc72bb7e_5
  r-igraph           conda-forge/linux-64::r-igraph-2.3.3-r45hf411e2a_0
  r-isoband          conda-forge/linux-64::r-isoband-0.3.0-r45h3697838_0
  r-jquerylib        conda-forge/noarch::r-jquerylib-0.1.4-r45hc72bb7e_4
  r-jsonlite         conda-forge/linux-64::r-jsonlite-2.0.0-r45h54b55ab_1
  r-kernsmooth       conda-forge/linux-64::r-kernsmooth-2.23_26-r45ha0a88a1_1
  r-knitr            conda-forge/noarch::r-knitr-1.51-r45hc72bb7e_0
  r-labeling         conda-forge/noarch::r-labeling-0.4.3-r45hc72bb7e_2
  r-lambda.r         conda-forge/noarch::r-lambda.r-1.2.4-r45hc72bb7e_5
  r-lattice          conda-forge/linux-64::r-lattice-0.22_9-r45h54b55ab_0
  r-lifecycle        conda-forge/noarch::r-lifecycle-1.0.5-r45hc72bb7e_0
  r-locfit           conda-forge/linux-64::r-locfit-1.5_9.12-r45h54b55ab_1
  r-lubridate        conda-forge/linux-64::r-lubridate-1.9.5-r45h54b55ab_0
  r-magrittr         conda-forge/linux-64::r-magrittr-2.0.5-r45h54b55ab_0
  r-matrix           conda-forge/linux-64::r-matrix-1.7_5-r45h0e4624f_0
  r-matrixstats      conda-forge/linux-64::r-matrixstats-1.5.0-r45h54b55ab_1
  r-memoise          conda-forge/noarch::r-memoise-2.0.1-r45hc72bb7e_4
  r-mgcv             conda-forge/linux-64::r-mgcv-1.9_4-r45h0e4624f_0
  r-mime             conda-forge/linux-64::r-mime-0.13-r45h54b55ab_1
  r-modelr           conda-forge/noarch::r-modelr-0.1.11-r45hc72bb7e_3
  r-munsell          conda-forge/noarch::r-munsell-0.5.1-r45hc72bb7e_2
  r-nlme             conda-forge/linux-64::r-nlme-3.1_170-r45heaba542_0
  r-openssl          conda-forge/linux-64::r-openssl-2.4.2-r45h68c19f5_0
  r-phangorn         conda-forge/linux-64::r-phangorn-2.12.1-r45hf1899b2_3
  r-pillar           conda-forge/noarch::r-pillar-1.11.1-r45hc72bb7e_0
  r-pkgconfig        conda-forge/noarch::r-pkgconfig-2.0.3-r45hc72bb7e_5
  r-plogr            conda-forge/noarch::r-plogr-0.2.0-r45hc72bb7e_1007
  r-plyr             conda-forge/linux-64::r-plyr-1.8.9-r45h3697838_3
  r-png              conda-forge/linux-64::r-png-0.1_9-r45haf2892b_0
  r-prettyunits      conda-forge/noarch::r-prettyunits-1.2.0-r45hc72bb7e_2
  r-processx         conda-forge/linux-64::r-processx-3.9.0-r45h54b55ab_0
  r-progress         conda-forge/noarch::r-progress-1.2.3-r45hc72bb7e_2
  r-ps               conda-forge/linux-64::r-ps-1.9.3-r45h54b55ab_0
  r-purrr            conda-forge/linux-64::r-purrr-1.2.2-r45h54b55ab_0
  r-quadprog         conda-forge/linux-64::r-quadprog-1.5_8-r45ha0a88a1_7
  r-r6               conda-forge/noarch::r-r6-2.6.1-r45hc72bb7e_1
  r-ragg             conda-forge/linux-64::r-ragg-1.5.2-r45h9f1dc4d_0
  r-rappdirs         conda-forge/linux-64::r-rappdirs-0.3.4-r45h54b55ab_0
  r-rcolorbrewer     conda-forge/noarch::r-rcolorbrewer-1.1_3-r45h785f33e_4
  r-rcpp             conda-forge/linux-64::r-rcpp-1.1.2-r45h3697838_0
  r-rcpparmadillo    conda-forge/linux-64::r-rcpparmadillo-15.4.2_1-r45h3704496_0
  r-rcurl            conda-forge/linux-64::r-rcurl-1.98_1.17-r45h46721d4_2
  r-readr            conda-forge/linux-64::r-readr-2.2.0-r45h3697838_0
  r-readxl           conda-forge/linux-64::r-readxl-1.5.0-r45h10e25cc_0
  r-rematch          conda-forge/noarch::r-rematch-2.0.0-r45hc72bb7e_2
  r-rematch2         conda-forge/noarch::r-rematch2-2.1.2-r45hc72bb7e_5
  r-reprex           conda-forge/noarch::r-reprex-2.1.1-r45hc72bb7e_2
  r-reshape2         conda-forge/linux-64::r-reshape2-1.4.5-r45h3697838_0
  r-restfulr         bioconda/linux-64::r-restfulr-0.0.17-r45hcdf289b_0
  r-rjson            conda-forge/linux-64::r-rjson-0.2.23-r45h3697838_1
  r-rlang            conda-forge/linux-64::r-rlang-1.3.0-r45h3697838_0
  r-rmarkdown        conda-forge/noarch::r-rmarkdown-2.31-r45hc72bb7e_0
  r-rsqlite          conda-forge/linux-64::r-rsqlite-3.53.1-r45h3697838_0
  r-rstudioapi       conda-forge/noarch::r-rstudioapi-0.19.0-r45hc72bb7e_0
  r-rvest            conda-forge/noarch::r-rvest-1.0.5-r45hc72bb7e_1
  r-s7               conda-forge/linux-64::r-s7-0.2.2-r45h54b55ab_0
  r-sass             conda-forge/linux-64::r-sass-0.4.10-r45h3697838_1
  r-scales           conda-forge/noarch::r-scales-1.4.0-r45hc72bb7e_1
  r-selectr          conda-forge/noarch::r-selectr-0.6_0-r45hc72bb7e_0
  r-sm               conda-forge/linux-64::r-sm-2.2_6.0-r45heaba542_2
  r-snow             conda-forge/noarch::r-snow-0.4_4-r45hc72bb7e_4
  r-statmod          conda-forge/linux-64::r-statmod-1.5.2-r45hb1d0f04_0
  r-stringi          conda-forge/linux-64::r-stringi-1.8.7-r45h2dae267_1
  r-stringr          conda-forge/noarch::r-stringr-1.6.0-r45h785f33e_0
  r-survival         conda-forge/linux-64::r-survival-3.8_9-r45h54b55ab_0
  r-sys              conda-forge/linux-64::r-sys-3.4.3-r45h54b55ab_1
  r-systemfonts      conda-forge/linux-64::r-systemfonts-1.3.2-r45h74f4acd_0
  r-textshaping      conda-forge/linux-64::r-textshaping-1.0.4-r45h74f4acd_0
  r-tibble           conda-forge/linux-64::r-tibble-3.3.1-r45h54b55ab_0
  r-tidyr            conda-forge/linux-64::r-tidyr-1.3.2-r45h3697838_0
  r-tidyselect       conda-forge/noarch::r-tidyselect-1.2.1-r45hc72bb7e_2
  r-tidyverse        conda-forge/noarch::r-tidyverse-2.0.0-r45h785f33e_3
  r-timechange       conda-forge/linux-64::r-timechange-0.4.0-r45h3697838_0
  r-tinytex          conda-forge/noarch::r-tinytex-0.60-r45hc72bb7e_0
  r-tzdb             conda-forge/linux-64::r-tzdb-0.5.0-r45h3697838_2
  r-utf8             conda-forge/linux-64::r-utf8-1.2.6-r45h54b55ab_1
  r-uuid             conda-forge/linux-64::r-uuid-1.2_2-r45h54b55ab_0
  r-vctrs            conda-forge/linux-64::r-vctrs-0.7.3-r45h3697838_0
  r-vioplot          conda-forge/noarch::r-vioplot-0.5.1-r45hc72bb7e_1
  r-viridislite      conda-forge/noarch::r-viridislite-0.4.3-r45hc72bb7e_0
  r-vroom            conda-forge/linux-64::r-vroom-1.7.1-r45h3697838_0
  r-withr            conda-forge/noarch::r-withr-3.0.3-r45hc72bb7e_0
  r-xfun             conda-forge/linux-64::r-xfun-0.60-r45h54b55ab_0
  r-xml              conda-forge/linux-64::r-xml-3.99_0.22-r45hf705907_0
  r-xml2             conda-forge/linux-64::r-xml2-1.6.0-r45he78afff_0
  r-xtable           conda-forge/noarch::r-xtable-1.8_8-r45hc72bb7e_0
  r-yaml             conda-forge/linux-64::r-yaml-2.3.12-r45h54b55ab_0
  r-zoo              conda-forge/linux-64::r-zoo-1.8_15-r45h54b55ab_0
  raxml              bioconda/linux-64::raxml-8.2.13-h7b50bb2_3
  readline           conda-forge/linux-64::readline-8.3-h853b02a_0
  requests           conda-forge/noarch::requests-2.34.2-pyhcf101f3_0
  rich               conda-forge/noarch::rich-15.0.0-pyhcf101f3_0
  salmon             bioconda/linux-64::salmon-2.3.4-hfa8f182_0
  samtools           bioconda/linux-64::samtools-1.23-h96c455f_0
  scikit-learn       conda-forge/linux-64::scikit-learn-1.9.0-np2py311ha15b03d_0
  scipy              conda-forge/linux-64::scipy-1.17.1-py311hbe70eeb_1
  seaborn-base       conda-forge/noarch::seaborn-base-0.13.2-pyhd8ed1ab_3
  sed                conda-forge/linux-64::sed-4.10-h19d0853_0
  setuptools         conda-forge/noarch::setuptools-80.10.2-pyh332efcf_0
  sip                conda-forge/linux-64::sip-6.10.0-py311h1ddb823_1
  six                conda-forge/noarch::six-1.17.0-pyhe01879c_1
  slclust            bioconda/linux-64::slclust-02022010-h077b44d_6
  snap               bioconda/linux-64::snap-2017_03_01-h7b50bb2_0
  sqlite             conda-forge/linux-64::sqlite-3.53.4-hbc0de68_0
  statsmodels        conda-forge/linux-64::statsmodels-0.14.6-py311h0372a8f_0
  stringtie          bioconda/linux-64::stringtie-3.0.3-h29c0135_0
  suitesparse        conda-forge/linux-64::suitesparse-7.10.1-ha0f6916_7100102
  sysroot_linux-64   conda-forge/noarch::sysroot_linux-64-2.34-h087de78_3
  tantan             bioconda/linux-64::tantan-51-h5ca1c30_1
  tar                conda-forge/linux-64::tar-1.35-h3b78370_0
  tbl2asn            bioconda/linux-64::tbl2asn-25.7-h9ee0642_1
  threadpoolctl      conda-forge/noarch::threadpoolctl-3.6.0-pyhecae5ae_0
  tk                 conda-forge/linux-64::tk-8.6.13-noxft_hd70dff1_3
  tktable            conda-forge/linux-64::tktable-2.10-h5a7a40f_8
  toml               conda-forge/noarch::toml-0.10.2-pyhcf101f3_3
  tomli              conda-forge/noarch::tomli-2.4.1-pyhcf101f3_0
  tomlkit            conda-forge/noarch::tomlkit-0.15.1-pyhcf101f3_0
  transdecoder       bioconda/noarch::transdecoder-6.0.0-pl5321hdfd78af_0
  trimal             bioconda/linux-64::trimal-1.5.1-h9948957_0
  trimmomatic        bioconda/noarch::trimmomatic-0.41-hdfd78af_0
  trinity            bioconda/linux-64::trinity-2.15.2-pl5321h077b44d_6
  trnascan-se        bioconda/linux-64::trnascan-se-2.0.13-pl5321hab16a5f_0
  typing_extensions  conda-forge/noarch::typing_extensions-4.16.0-pyhcf101f3_0
  tzdata             conda-forge/noarch::tzdata-2026c-h151e31d_0
  ucsc-blat          bioconda/linux-64::ucsc-blat-482-hdc0a859_0
  ucsc-fatotwobit    bioconda/linux-64::ucsc-fatotwobit-482-hdc0a859_0
  ucsc-pslcdnafilter bioconda/linux-64::ucsc-pslcdnafilter-482-h0b57e2e_0
  ucsc-twobitinfo    bioconda/linux-64::ucsc-twobitinfo-482-hdc0a859_0
  unicodedata2       conda-forge/linux-64::unicodedata2-17.0.1-py311h49ec1c0_0
  urllib3            conda-forge/noarch::urllib3-2.7.0-pyhd8ed1ab_0
  wayland            conda-forge/linux-64::wayland-1.26.0-hd6090a7_0
  wget               conda-forge/linux-64::wget-1.25.0-h653f8fd_1
  wheel              conda-forge/noarch::wheel-0.47.0-pyhd8ed1ab_0
  xcb-util           conda-forge/linux-64::xcb-util-0.4.1-h4f16b4b_2
  xcb-util-image     conda-forge/linux-64::xcb-util-image-0.4.0-hb711507_2
  xcb-util-keysyms   conda-forge/linux-64::xcb-util-keysyms-0.4.1-hb711507_0
  xcb-util-renderut~ conda-forge/linux-64::xcb-util-renderutil-0.3.10-hb711507_0
  xcb-util-wm        conda-forge/linux-64::xcb-util-wm-0.4.2-hb711507_0
  xkeyboard-config   conda-forge/linux-64::xkeyboard-config-2.48-h280c20c_0
  xlsxwriter         conda-forge/noarch::xlsxwriter-3.2.9-pyhd8ed1ab_0
  xmltodict          conda-forge/noarch::xmltodict-1.0.4-pyhcf101f3_0
  xorg-libice        conda-forge/linux-64::xorg-libice-1.1.2-hb9d3cd8_0
  xorg-libsm         conda-forge/linux-64::xorg-libsm-1.2.6-he73a12e_0
  xorg-libx11        conda-forge/linux-64::xorg-libx11-1.8.13-he1eb515_0
  xorg-libxau        conda-forge/linux-64::xorg-libxau-1.0.12-hb03c661_1
  xorg-libxcomposite conda-forge/linux-64::xorg-libxcomposite-0.4.7-hb03c661_0
  xorg-libxcursor    conda-forge/linux-64::xorg-libxcursor-1.2.3-hb9d3cd8_0
  xorg-libxdamage    conda-forge/linux-64::xorg-libxdamage-1.1.6-hb9d3cd8_0
  xorg-libxdmcp      conda-forge/linux-64::xorg-libxdmcp-1.1.5-hb03c661_1
  xorg-libxext       conda-forge/linux-64::xorg-libxext-1.3.7-hb03c661_0
  xorg-libxfixes     conda-forge/linux-64::xorg-libxfixes-6.0.2-hb03c661_0
  xorg-libxi         conda-forge/linux-64::xorg-libxi-1.8.3-hb03c661_0
  xorg-libxinerama   conda-forge/linux-64::xorg-libxinerama-1.1.6-hecca717_0
  xorg-libxrandr     conda-forge/linux-64::xorg-libxrandr-1.5.5-hb03c661_0
  xorg-libxrender    conda-forge/linux-64::xorg-libxrender-0.9.12-hb9d3cd8_0
  xorg-libxshmfence  conda-forge/linux-64::xorg-libxshmfence-1.3.3-hb9d3cd8_0
  xorg-libxt         conda-forge/linux-64::xorg-libxt-1.3.1-hb9d3cd8_0
  xorg-libxtst       conda-forge/linux-64::xorg-libxtst-1.2.5-hb9d3cd8_3
  xorg-libxxf86vm    conda-forge/linux-64::xorg-libxxf86vm-1.1.7-hb03c661_0
  xorg-xextproto     conda-forge/linux-64::xorg-xextproto-7.3.0-hb9d3cd8_1004
  xorg-xorgproto     conda-forge/linux-64::xorg-xorgproto-2025.1-hb03c661_0
  xz                 conda-forge/linux-64::xz-5.8.3-ha02ee65_0
  xz-gpl-tools       conda-forge/linux-64::xz-gpl-tools-5.8.3-ha02ee65_0
  xz-tools           conda-forge/linux-64::xz-tools-5.8.3-hb03c661_0
  yaml               conda-forge/linux-64::yaml-0.2.5-h280c20c_3
  yq                 conda-forge/noarch::yq-4.1.2-pyhcf101f3_1
  zlib               conda-forge/linux-64::zlib-1.3.2-h25fd6f3_2
  zlib-ng            conda-forge/linux-64::zlib-ng-2.3.3-hceb46e0_1
  zstd               conda-forge/linux-64::zstd-1.5.7-hb78ec9c_6


Proceed ([y]/n)? y


Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: \
-
For Linux 64, Open MPI is built with CUDA awareness but this support is disabled by default.
To enable it, please set the environment variable OMPI_MCA_opal_cuda_support=true before
launching your MPI processes. Equivalently, you can set the MCA parameter in the command line:
mpiexec --mca opal_cuda_support 1 ...

In addition, the UCX support is also built but disabled by default.
To enable it, first install UCX (conda install -c conda-forge ucx). Then, set the environment
variables OMPI_MCA_pml="ucx" OMPI_MCA_osc="ucx" before launching your MPI processes.
Equivalently, you can set the MCA parameters in the command line:
mpiexec --mca pml ucx --mca osc ucx ...
Note that you might also need to set UCX_MEMTYPE_CACHE=n for CUDA awareness via UCX.
Please consult UCX's documentation for detail.


|
/
-
##########################################################################################
All Users:
  You will need to setup the funannotate databases using funannotate setup.
  The location of these databases on the file system is your decision and the
  location can be defined using the FUNANNOTATE_DB environmental variable.

  To set this up in your conda environment you can run the following:
    echo "export FUNANNOTATE_DB=/your/path" > /mnt/apps/users/pcock/conda/envs/funannotate/etc/conda/activate.d/funannotate.sh
    echo "unset FUNANNOTATE_DB" > /mnt/apps/users/pcock/conda/envs/funannotate/etc/conda/deactivate.d/funannotate.sh

  You can then run your database setup using funannotate:
    funannotate setup -i all

  Due to licensing restrictions, if you want to use GeneMark-ES/ET, you will need to install manually:
  download and follow directions at http://topaz.gatech.edu/GeneMark/license_download.cgi
  ** note you will likely need to change shebang line for all perl scripts:
    change: #!/usr/bin/perl to #!/usr/bin/env perl


Mac OSX Users:
  Augustus and Trinity cannot be properly installed via conda/bioconda at this time. However,
  they are able to be installed manually using a local copy of GCC (gcc-8 in example below).

  Install augustus using this repo:
    https://github.com/nextgenusfs/augustus

  To install Trinity v2.15.2, download the source code and compile using GCC/G++:
    wget https://github.com/trinityrnaseq/trinityrnaseq/releases/download/Trinity-v2.15.2/trinityrnaseq-v2.15.2.FULL.tar.gz
    tar xzvf trinityrnaseq-v2.15.2.FULL.tar.gz
    cd trinityrnaseq-v2.15.2
    make CC=gcc-8 CXX=g++-8
    echo "export TRINITY_HOME=/your/path" > /mnt/apps/users/pcock/conda/envs/funannotate/etc/conda/activate.d/trinity.sh
    echo "unset TRINITY_HOME" > /mnt/apps/users/pcock/conda/envs/funannotate/etc/conda/deactivate.d/trinity.sh

##########################################################################################

done
#
# To activate this environment, use
#
#     $ conda activate funannotate
#
# To deactivate an active environment, use
#
#     $ conda deactivate
```

</details>